### PR TITLE
Add Read and Write wrappers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,6 +529,8 @@ mod handles;
 mod data;
 mod variant;
 
+pub mod stream;
+
 use variant::*;
 use utf_8::utf8_valid_up_to;
 use ascii::ascii_valid_up_to;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,106 @@
+// Copyright 2015-2016 Mozilla Foundation. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::io;
+use std::mem;
+use std::ops::Range;
+use std::str;
+use super::Decoder;
+
+pub use std::io::Write as WriteBytes;
+pub use std::io::Read as ReadBytes;
+pub use std::fmt::Write as WriteUnicode;
+
+pub trait ReadUnicode {
+    fn read(&mut self, buf: &mut str) -> io::Result<usize>;
+}
+
+impl<'a, S: ReadUnicode> ReadUnicode for &'a mut S {
+    fn read(&mut self, buf: &mut str) -> io::Result<usize> {
+        (**self).read(buf)
+    }
+}
+
+/// Similar to `std::io::Read for &'a [u8]`.
+impl<'a> ReadUnicode for &'a str {
+    fn read(&mut self, buf: &mut str) -> io::Result<usize> {
+        let self_bytes = self.as_bytes();
+        let bytes_to_copy = if buf.len() >= self.len() {
+            self.len()
+        } else {
+            let mut i = buf.len() - 1;
+            while (self_bytes[i] & 0xC0) == 0x80 {
+                i -= 1;
+            }
+            i
+        };
+        let buf_bytes: &mut [u8] = unsafe { mem::transmute(buf) };
+        let (to_copy_from, remaining_self) = self.split_at(bytes_to_copy);
+        let (to_copy_into, remaining_buf) = buf_bytes.split_at_mut(bytes_to_copy);
+        to_copy_into.copy_from_slice(to_copy_from.as_bytes());
+        for byte in remaining_buf {
+            if (*byte & 0xC0) == 0x80 {
+                *byte = 0
+            } else {
+                break
+            }
+        }
+        *self = remaining_self;
+        Ok(bytes_to_copy)
+    }
+}
+
+// FIXME: with vs without replacement
+
+pub struct ReadDecoder<Stream: ReadBytes, Buffer: AsMut<[u8]>> {
+    decoder: Decoder,
+    stream: Stream,
+    reached_stream_eof: bool,
+    buffer: Buffer,
+    unused_buffer_slice: Range<usize>,
+}
+
+impl<Stream: ReadBytes, Buffer: AsMut<[u8]>> ReadDecoder<Stream, Buffer> {
+    pub fn new(decoder: Decoder, stream: Stream, buffer: Buffer) -> Self {
+        ReadDecoder {
+            decoder: decoder,
+            stream: stream,
+            reached_stream_eof: false,
+            buffer: buffer,
+            unused_buffer_slice: 0..0,
+        }
+    }
+}
+
+impl<Stream: ReadBytes, Buffer: AsMut<[u8]>> ReadUnicode for ReadDecoder<Stream, Buffer> {
+    fn read(&mut self, dst: &mut str) -> io::Result<usize> {
+        let buffer = self.buffer.as_mut();
+        if self.unused_buffer_slice.end > self.unused_buffer_slice.start {
+            let buffer_slice = &buffer[self.unused_buffer_slice.clone()];
+            let mut buffer_slice = unsafe { str::from_utf8_unchecked(buffer_slice) };
+            let bytes_copied = ReadUnicode::read(&mut buffer_slice, dst)?;
+            self.unused_buffer_slice.start += bytes_copied;
+            Ok(bytes_copied)
+        } else if !self.reached_stream_eof {
+            let bytes_in_buffer = ReadBytes::read(&mut self.stream, buffer)?;
+            if bytes_in_buffer == 0 {
+                self.reached_stream_eof = true;
+                let (_, _, written, _) = self.decoder.decode_to_str(b"", dst, true);
+                Ok(written)
+            } else {
+                let (_, bytes_read, bytes_written, _) = self.decoder.decode_to_str(
+                    &buffer[..bytes_in_buffer], dst, false);
+                self.unused_buffer_slice = bytes_read..bytes_in_buffer;
+                Ok(bytes_written)
+            }
+        } else {
+            Ok(0)
+        }
+    }
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -18,43 +18,50 @@ pub use std::io::Read as ReadBytes;
 pub use std::fmt::Write as WriteUnicode;
 
 pub trait ReadUnicode {
-    fn read(&mut self, buf: &mut str) -> io::Result<usize>;
+    fn read(&mut self, dst: &mut str) -> io::Result<usize>;
 }
 
 impl<'a, S: ReadUnicode> ReadUnicode for &'a mut S {
-    fn read(&mut self, buf: &mut str) -> io::Result<usize> {
-        (**self).read(buf)
+    fn read(&mut self, dst: &mut str) -> io::Result<usize> {
+        (**self).read(dst)
     }
 }
 
 /// Similar to `std::io::Read for &'a [u8]`.
 impl<'a> ReadUnicode for &'a str {
-    fn read(&mut self, buf: &mut str) -> io::Result<usize> {
-        let self_bytes = self.as_bytes();
-        let bytes_to_copy = if buf.len() >= self.len() {
-            self.len()
-        } else {
-            let mut i = buf.len() - 1;
-            while (self_bytes[i] & 0xC0) == 0x80 {
-                i -= 1;
-            }
-            i
-        };
-        let buf_bytes = unsafe { mem::transmute::<&mut str, &mut [u8]>(buf) };
-        let (to_copy_from, remaining_self) = self.split_at(bytes_to_copy);
-        let (to_copy_into, remaining_buf) = buf_bytes.split_at_mut(bytes_to_copy);
-        to_copy_into.copy_from_slice(to_copy_from.as_bytes());
-        for byte in remaining_buf {
-            if (*byte & 0xC0) == 0x80 {
-                *byte = 0
-            } else {
-                break
-            }
-        }
+    fn read(&mut self, dst: &mut str) -> io::Result<usize> {
+        // Unsafe: copy_maximum_utf8_prefix carefully preserves UTF-8 wel-formedness.
+        let dst_bytes = unsafe { mem::transmute::<&mut str, &mut [u8]>(dst) };
+        let (bytes_copied, remaining_self) = copy_maximum_utf8_prefix(*self, dst_bytes);
         *self = remaining_self;
-        Ok(bytes_to_copy)
+        Ok(bytes_copied)
     }
 }
+
+fn copy_maximum_utf8_prefix<'a>(src: &'a str, dst: &mut [u8]) -> (usize, &'a str) {
+    let src_bytes = src.as_bytes();
+    let bytes_to_copy = if dst.len() >= src.len() {
+        src.len()
+    } else {
+        let mut i = dst.len() - 1;
+        while (src_bytes[i] & 0xC0) == 0x80 {
+            i -= 1;
+        }
+        i
+    };
+    let (to_copy_from, remaining_src) = src.split_at(bytes_to_copy);
+    let (to_copy_into, remaining_dst) = dst.split_at_mut(bytes_to_copy);
+    to_copy_into.copy_from_slice(to_copy_from.as_bytes());
+    for byte in remaining_dst {
+        if (*byte & 0xC0) == 0x80 {
+            *byte = 0
+        } else {
+            break
+        }
+    }
+    (bytes_to_copy, remaining_src)
+}
+
 
 // FIXME: with vs without replacement
 
@@ -80,6 +87,8 @@ impl<Stream: ReadBytes, Buffer: AsMut<[u8]>> ReadDecoder<Stream, Buffer> {
 
 impl<Stream: ReadBytes, Buffer: AsMut<[u8]>> ReadUnicode for ReadDecoder<Stream, Buffer> {
     fn read(&mut self, dst: &mut str) -> io::Result<usize> {
+        // Unsafe: Like Decoder::decode_to_utf8, <ReadDecoder as ReadBytes>::read’s contract
+        // is to preserve UTF-8 well-formedness.
         let dst = unsafe { mem::transmute::<&mut str, &mut [u8]>(dst) };
         ReadBytes::read(self, dst)
     }
@@ -90,13 +99,10 @@ impl<Stream: ReadBytes, Buffer: AsMut<[u8]>> ReadBytes for ReadDecoder<Stream, B
         let buffer = self.buffer.as_mut();
         if self.unused_buffer_slice.end > self.unused_buffer_slice.start {
             let buffer_slice = &buffer[self.unused_buffer_slice.clone()];
-            let mut buffer_slice = unsafe { str::from_utf8_unchecked(buffer_slice) };
-
-            // This transmute is a lie: `dst` might not be UTF-8 at all.
-            // But we know that `<&str as ReadUnicode>::read` doesn’t rely on it being UTF-8.
-            let dst = unsafe { mem::transmute::<&mut [u8], &mut str>(dst) };
-
-            let bytes_copied = ReadUnicode::read(&mut buffer_slice, dst)?;
+            // Unsafe: this slice was written by Decoder::decode_to_utf8,
+            // whose contract is to make it well-formed UTF-8.
+            let buffer_slice = unsafe { str::from_utf8_unchecked(buffer_slice) };
+            let (bytes_copied, _) = copy_maximum_utf8_prefix(buffer_slice, dst);
             self.unused_buffer_slice.start += bytes_copied;
             Ok(bytes_copied)
         } else if !self.reached_stream_eof {


### PR DESCRIPTION
Implement the wrapper types described in https://github.com/hsivonen/encoding_rs/issues/8#issuecomment-285057121.

This is not ready for merging, but I’m opening it for discussion. It needs at least some docs and tests, but more importantly while this demonstrates that all four types and five impls included here are *possible*, I don’t know if they’re all *useful* or which if any belong in this repository.

In https://github.com/hsivonen/encoding_rs/issues/8#issuecomment-285057121 I mentioned a fifth possible wrapper type, but that one can be another `impl` for one of the other four. (See second commit of this PR.)

In each case a buffer is needed for temporary space. In the `*Write` case a `&mut [u8]` of that buffer is passed to the underlying stream which is only expected to write to it, but since that stream there is nothing stopping an unusual impl from reading from the buffer. This means that an uninitialized should not be used unless the stream is known not to read form it. (This is the case of `std::io::Read for std::fs::File`, for example.) On the other hand, initializing a buffer (e.g. with zeros) has a cost that some users may want to avoid. This is why the buffer is also generic, to leave up to users to decide. (The buffers could also be taken as `&mut [u8]`, but that would add a mandatory lifetime parameter to the wrapper types.)

Buffers of less than 4 bytes (or can that number be higher for encoding other than UTF-8?) can cause infinite loops, with a stream unable to make progress. Larger sizes are probably better for performance. For example `[u8; 1024]` on the stack seems nice, though I totally just pulled that number out of thin air.

Currently `WriteDecoder` and `WriteEncoder` signal the end of the stream when dropped, but errors (such as I/O errors) from the underlying stream that occur at that time are ignored since `Drop::drop` cannot return a `Result`, and panicking in a destructor is generally avoided. (Other destructors are still run after one panic, but panicking while panicking causes the process to abort.) Perhaps an `fn end(&mut self) -> Result` method could be added to each of them to allow users to signal the end of the stream and handle errors. @hsivonen, is it OK to call `encoder.encode_from_utf8("", buffer, /* last = */ true)` or `decoder.decode_to_utf8(b"", buffer, /* last = */ true)` twice?

CC @BurntSushi