### PR TITLE
Remove () from usize().

### DIFF
--- a/src/utf_16.rs
+++ b/src/utf_16.rs
@@ -30,7 +30,7 @@ impl Utf16Decoder {
         )
     }
 
-    pub fn additional_from_state(&self) -> usize() {
+    pub fn additional_from_state(&self) -> usize {
         1 + if self.lead_byte.is_some() { 1 } else { 0 } +
         if self.lead_surrogate == 0 { 0 } else { 2 }
     }


### PR DESCRIPTION
Parentheses after primitive types will be prohibited in the future by rust-lang/rust#42238. This patch will remove the parentheses.