### PR TITLE
Use full github url for safe_encoding_rs_mem

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies.encoding_rs]
 path = ".."
 [dependencies.safe_encoding_rs_mem]
-path = "../../safe_encoding_rs_mem"
+git = "https://github.com/hsivonen/safe_encoding_rs_mem"
 [dependencies.libfuzzer-sys]
 git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
 


### PR DESCRIPTION
The ../../safe_encoding_rs_mem path points outside of the repository.