### PR TITLE
remove unstable scoped lint

### DIFF
--- a/generate-encoding-data.py
+++ b/generate-encoding-data.py
@@ -476,7 +476,7 @@ for code_point in index[942:19782]:
 for j in xrange(32 - (len(astralness) % 32)):
   astralness.append(0)
 
-data_file.write('''#[cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+data_file.write('''#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 static BIG5_ASTRALNESS: [u32; %d] = [
 ''' % (len(astralness) / 32))
 

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -92,7 +92,7 @@ macro_rules! ascii_alu {
      $stride_fn:ident) => {
         #[cfg_attr(
             feature = "cargo-clippy",
-            allow(clippy::never_loop, clippy::cast_ptr_alignment)
+            allow(never_loop, cast_ptr_alignment)
         )]
         #[inline(always)]
         pub unsafe fn $name(
@@ -187,9 +187,9 @@ macro_rules! basic_latin_alu {
         #[cfg_attr(
             feature = "cargo-clippy",
             allow(
-                clippy::never_loop,
-                clippy::cast_ptr_alignment,
-                clippy::cast_lossless
+                never_loop,
+                cast_ptr_alignment,
+                cast_lossless
             )
         )]
         #[inline(always)]
@@ -286,9 +286,9 @@ macro_rules! latin1_alu {
         #[cfg_attr(
             feature = "cargo-clippy",
             allow(
-                clippy::never_loop,
-                clippy::cast_ptr_alignment,
-                clippy::cast_lossless
+                never_loop,
+                cast_ptr_alignment,
+                cast_lossless
             )
         )]
         #[inline(always)]
@@ -1377,7 +1377,7 @@ cfg_if! {
             find_non_ascii(word, second_word)
         }
 
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
+        #[cfg_attr(feature = "cargo-clippy", allow(cast_ptr_alignment))]
         #[inline(always)]
         pub fn validate_ascii(slice: &[u8]) -> Option<(u8, usize)> {
             let src = slice.as_ptr();

--- a/src/data.rs
+++ b/src/data.rs
@@ -422,7 +422,7 @@ pub static SINGLE_BYTE_DATA: SingleByteData = SingleByteData {
     ],
 };
 
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::unreadable_literal))]
+#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 static BIG5_ASTRALNESS: [u32; 589] = [
     0x445F0520, 0xB882520F, 0x400000F8, 0x044EA920, 0x00000000, 0x00010B34, 0x00000000, 0x00000000,
     0x00000000, 0x0C000000, 0x00000040, 0x00000000, 0x00580400, 0x0000003C, 0x5C800000, 0xBBF3DCAD,

--- a/src/handles.rs
+++ b/src/handles.rs
@@ -1146,7 +1146,7 @@ impl<'a> Utf16Source<'a> {
             Space::Full(self.consumed())
         }
     }
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::collapsible_if))]
+    #[cfg_attr(feature = "cargo-clippy", allow(collapsible_if))]
     #[inline(always)]
     fn read(&mut self) -> char {
         self.old_pos = self.pos;
@@ -1180,7 +1180,7 @@ impl<'a> Utf16Source<'a> {
         // Unpaired low surrogate
         '\u{FFFD}'
     }
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::collapsible_if))]
+    #[cfg_attr(feature = "cargo-clippy", allow(collapsible_if))]
     #[inline(always)]
     fn read_enum(&mut self) -> Unicode {
         self.old_pos = self.pos;

--- a/src/iso_2022_jp.rs
+++ b/src/iso_2022_jp.rs
@@ -368,8 +368,8 @@ fn is_kanji_mapped(bmp: u16) -> bool {
 #[cfg_attr(
     feature = "cargo-clippy",
     allow(
-        clippy::if_let_redundant_pattern_matching,
-        clippy::if_same_then_else
+        if_let_redundant_pattern_matching,
+        if_same_then_else
     )
 )]
 #[inline(always)]
@@ -392,8 +392,8 @@ fn is_kanji_mapped(bmp: u16) -> bool {
 #[cfg_attr(
     feature = "cargo-clippy",
     allow(
-        clippy::if_let_redundant_pattern_matching,
-        clippy::if_same_then_else
+        if_let_redundant_pattern_matching,
+        if_same_then_else
     )
 )]
 fn is_mapped_for_two_byte_encode(bmp: u16) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@
 #![cfg_attr(
     feature = "cargo-clippy",
     allow(
-        clippy::doc_markdown,
-        clippy::inline_always,
-        clippy::new_ret_no_self
+        doc_markdown,
+        inline_always,
+        new_ret_no_self
     )
 )]
 #![doc(html_root_url = "https://docs.rs/encoding_rs/0.8.11")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -361,7 +361,7 @@ macro_rules! gb18030_decoder_function {
      $name:ident,
      $code_unit:ty,
      $dest_struct:ident) => (
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::never_loop))]
+    #[cfg_attr(feature = "cargo-clippy", allow(never_loop))]
     pub fn $name(&mut $slf,
                  src: &[u8],
                  dst: &mut [$code_unit],
@@ -686,7 +686,7 @@ macro_rules! euc_jp_decoder_function {
      $name:ident,
      $code_unit:ty,
      $dest_struct:ident) => (
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::never_loop))]
+    #[cfg_attr(feature = "cargo-clippy", allow(never_loop))]
     pub fn $name(&mut $slf,
                  src: &[u8],
                  dst: &mut [$code_unit],

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -72,7 +72,7 @@ const LATIN1_MASK: usize = 0xFF00_FF00_FF00_FF00u64 as usize;
 #[allow(unused_macros)]
 macro_rules! by_unit_check_alu {
     ($name:ident, $unit:ty, $bound:expr, $mask:ident) => {
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
+        #[cfg_attr(feature = "cargo-clippy", allow(cast_ptr_alignment))]
         #[inline(always)]
         fn $name(buffer: &[$unit]) -> bool {
             let mut offset = 0usize;
@@ -308,7 +308,7 @@ cfg_if!{
 
 /// The second return value is true iff the last code unit of the slice was
 /// reached and turned out to be a low surrogate that is part of a valid pair.
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::collapsible_if))]
+#[cfg_attr(feature = "cargo-clippy", allow(collapsible_if))]
 #[inline(always)]
 fn utf16_valid_up_to_alu(buffer: &[u16]) -> (usize, bool) {
     let len = buffer.len();
@@ -563,7 +563,7 @@ cfg_if!{
             }
         }
     } else {
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
+        #[cfg_attr(feature = "cargo-clippy", allow(cast_ptr_alignment))]
         #[inline(always)]
         fn check_utf16_for_latin1_and_bidi_impl(buffer: &[u16]) -> Latin1Bidi {
             let mut offset = 0usize;
@@ -689,7 +689,7 @@ pub fn is_utf16_latin1(buffer: &[u16]) -> bool {
 /// no RTL characters.
 #[cfg_attr(
     feature = "cargo-clippy",
-    allow(clippy::collapsible_if, clippy::cyclomatic_complexity)
+    allow(collapsible_if, cyclomatic_complexity)
 )]
 #[inline]
 pub fn is_utf8_bidi(buffer: &[u8]) -> bool {
@@ -1110,7 +1110,7 @@ pub fn is_utf8_bidi(buffer: &[u8]) -> bool {
 /// cause right-to-left behavior without the presence of right-to-left
 /// characters or right-to-left controls are not checked for. As a special
 /// case, U+FEFF is excluded from Arabic Presentation Forms-B.
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::collapsible_if))]
+#[cfg_attr(feature = "cargo-clippy", allow(collapsible_if))]
 #[inline]
 pub fn is_str_bidi(buffer: &str) -> bool {
     // U+058F: D6 8F

--- a/src/utf_8.rs
+++ b/src/utf_8.rs
@@ -235,7 +235,7 @@ pub fn utf8_valid_up_to(src: &[u8]) -> usize {
 
 #[cfg_attr(
     feature = "cargo-clippy",
-    allow(clippy::never_loop, clippy::cyclomatic_complexity)
+    allow(never_loop, cyclomatic_complexity)
 )]
 pub fn convert_utf8_to_utf16_up_to_invalid(src: &[u8], dst: &mut [u16]) -> (usize, usize) {
     // This algorithm differs from the UTF-8 validation algorithm, but making
@@ -633,7 +633,7 @@ impl Utf8Encoder {
         Some(byte_length)
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::never_loop))]
+    #[cfg_attr(feature = "cargo-clippy", allow(never_loop))]
     pub fn encode_from_utf16_raw(
         &mut self,
         src: &[u16],


### PR DESCRIPTION
the scoped lint is currently experimental and hence cannot be used on stable channel. This affects all crate that depends on this crate, and all crates that (implicitly) depends on `encoding_rs` cannot use  `clippy-preview` on stable channel.