### PR TITLE
Make encoding lists public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2129,7 +2129,7 @@ pub static X_USER_DEFINED_INIT: Encoding = Encoding {
 /// `static`.
 pub static X_USER_DEFINED: &'static Encoding = &X_USER_DEFINED_INIT;
 
-static LABELS_SORTED: [&'static str; 219] = [
+pub static LABELS_SORTED: [&'static str; 219] = [
     "l1",
     "l2",
     "l3",
@@ -2351,7 +2351,7 @@ static LABELS_SORTED: [&'static str; 219] = [
     "cseucpkdfmtjapanese",
 ];
 
-static ENCODINGS_IN_LABEL_SORT: [&'static Encoding; 219] = [
+pub static ENCODINGS_IN_LABEL_SORT: [&'static Encoding; 219] = [
     &WINDOWS_1252_INIT,
     &ISO_8859_2_INIT,
     &ISO_8859_3_INIT,


### PR DESCRIPTION
I recently migrated [Stringsext, a GNU Strings Alternative with Multi-Byte-Encoding Support](https://github.com/getreu/stringsext) from [rust-encoding](https://github.com/lifthrasiir/rust-encoding) to [encoding_rs](https://github.com/hsivonen/encoding_rs/).

The Stringsext tool prints la list of supported encoding names. As the lists in `encoding_rs` are not public, I had to copy them in my source code, which is an error prone duplication of code I would like to avoid.