### PR TITLE
Fixed UB in big5::tests::test_big5_decode flagged by Miri.

### DIFF
--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -211,7 +211,7 @@ macro_rules! basic_latin_alu {
                         let src_until_alignment = (ALU_ALIGNMENT
                             - ((src as usize) & ALU_ALIGNMENT_MASK))
                             & ALU_ALIGNMENT_MASK;
-                        if (dst.add(src_until_alignment) as usize) & ALU_ALIGNMENT_MASK != 0 {
+                        if (dst.wrapping_add(src_until_alignment) as usize) & ALU_ALIGNMENT_MASK != 0 {
                             break;
                         }
                         src_until_alignment


### PR DESCRIPTION
Fixes the out-of-bound UB in #52. 

Looks like replacing `dst.add ` with `dst.wrapping_add` is sufficient to stop UB from occurring, while passing all existing test cases.

Run 
`cargo miri test -- -Zmiri-disable-alignment-check -- big5::tests::test_big5_decode` to confirm that the UB is fixed.