### PR TITLE
adjust tests to Miri

### DIFF
--- a/generate-encoding-data.py
+++ b/generate-encoding-data.py
@@ -1446,12 +1446,20 @@ single_byte_file.write("""
     #[test]
     fn test_single_byte_decode() {""")
 
+idx = 0 # for Miri, return after 2nd test
 for name in preferred:
   if name == u"ISO-8859-8-I":
     continue;
   if is_single_byte(name):
     single_byte_file.write("""
         decode_single_byte(%s, &data::SINGLE_BYTE_DATA.%s);""" % (to_constant_name(name), to_snake_name(name)))
+    idx += 1
+    if idx == 2:
+      single_byte_file.write("""
+        if cfg!(miri) {
+            // Miri is too slow
+            return;
+        }""")
 
 single_byte_file.write("""
     }
@@ -1459,12 +1467,21 @@ single_byte_file.write("""
     #[test]
     fn test_single_byte_encode() {""")
 
+
+idx = 0 # for Miri, return after 2nd test
 for name in preferred:
   if name == u"ISO-8859-8-I":
     continue;
   if is_single_byte(name):
     single_byte_file.write("""
         encode_single_byte(%s, &data::SINGLE_BYTE_DATA.%s);""" % (to_constant_name(name), to_snake_name(name)))
+    idx += 1
+    if idx == 2:
+      single_byte_file.write("""
+        if cfg!(miri) {
+            // Miri is too slow
+            return;
+        }""")
 
 
 single_byte_file.write("""

--- a/src/big5.rs
+++ b/src/big5.rs
@@ -365,18 +365,20 @@ mod tests {
         // ASCII
         encode_big5("\u{0061}\u{0062}", b"\x61\x62");
 
-        // Edge cases
-        encode_big5("\u{9EA6}\u{0061}", b"&#40614;\x61");
-        encode_big5("\u{2626B}\u{0061}", b"&#156267;\x61");
-        encode_big5("\u{3000}", b"\xA1\x40");
-        encode_big5("\u{20AC}", b"\xA3\xE1");
-        encode_big5("\u{4E00}", b"\xA4\x40");
-        encode_big5("\u{27607}", b"\xC8\xA4");
-        encode_big5("\u{FFE2}", b"\xC8\xCD");
-        encode_big5("\u{79D4}", b"\xFE\xFE");
+        if !cfg!(miri) { // Miri is too slow
+            // Edge cases
+            encode_big5("\u{9EA6}\u{0061}", b"&#40614;\x61");
+            encode_big5("\u{2626B}\u{0061}", b"&#156267;\x61");
+            encode_big5("\u{3000}", b"\xA1\x40");
+            encode_big5("\u{20AC}", b"\xA3\xE1");
+            encode_big5("\u{4E00}", b"\xA4\x40");
+            encode_big5("\u{27607}", b"\xC8\xA4");
+            encode_big5("\u{FFE2}", b"\xC8\xCD");
+            encode_big5("\u{79D4}", b"\xFE\xFE");
 
-        // Not in index
-        encode_big5("\u{2603}\u{0061}", b"&#9731;\x61");
+            // Not in index
+            encode_big5("\u{2603}\u{0061}", b"&#9731;\x61");
+        }
 
         // duplicate low bits
         encode_big5("\u{203B5}", b"\xFD\x6A");
@@ -387,6 +389,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_big5_decode_all() {
         let input = include_bytes!("test_data/big5_in.txt");
         let expectation = include_str!("test_data/big5_in_ref.txt");
@@ -396,6 +399,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_big5_encode_all() {
         let input = include_str!("test_data/big5_out.txt");
         let expectation = include_bytes!("test_data/big5_out_ref.txt");
@@ -406,6 +410,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_big5_encode_from_two_low_surrogates() {
         let expectation = b"&#65533;&#65533;";
         let mut output = [0u8; 40];

--- a/src/euc_jp.rs
+++ b/src/euc_jp.rs
@@ -437,6 +437,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_jis0208_decode_all() {
         let input = include_bytes!("test_data/jis0208_in.txt");
         let expectation = include_str!("test_data/jis0208_in_ref.txt");
@@ -446,6 +447,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_jis0208_encode_all() {
         let input = include_str!("test_data/jis0208_out.txt");
         let expectation = include_bytes!("test_data/jis0208_out_ref.txt");
@@ -456,6 +458,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_jis0212_decode_all() {
         let input = include_bytes!("test_data/jis0212_in.txt");
         let expectation = include_str!("test_data/jis0212_in_ref.txt");

--- a/src/euc_kr.rs
+++ b/src/euc_kr.rs
@@ -406,6 +406,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_euc_kr_decode_all() {
         let input = include_bytes!("test_data/euc_kr_in.txt");
         let expectation = include_str!("test_data/euc_kr_in_ref.txt");
@@ -415,6 +416,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_euc_kr_encode_all() {
         let input = include_str!("test_data/euc_kr_out.txt");
         let expectation = include_bytes!("test_data/euc_kr_out_ref.txt");

--- a/src/gb18030.rs
+++ b/src/gb18030.rs
@@ -653,12 +653,14 @@ mod tests {
         // two bytes
         encode_gb18030("\u{4E02}", b"\x81\x40");
         encode_gb18030("\u{4E8A}", b"\x81\x7E");
-        encode_gb18030("\u{4E90}", b"\x81\x80");
-        encode_gb18030("\u{4FA2}", b"\x81\xFE");
-        encode_gb18030("\u{FA0C}", b"\xFE\x40");
-        encode_gb18030("\u{E843}", b"\xFE\x7E");
-        encode_gb18030("\u{4723}", b"\xFE\x80");
-        encode_gb18030("\u{E4C5}", b"\xFE\xFE");
+        if !cfg!(miri) { // Miri is too slow
+            encode_gb18030("\u{4E90}", b"\x81\x80");
+            encode_gb18030("\u{4FA2}", b"\x81\xFE");
+            encode_gb18030("\u{FA0C}", b"\xFE\x40");
+            encode_gb18030("\u{E843}", b"\xFE\x7E");
+            encode_gb18030("\u{4723}", b"\xFE\x80");
+            encode_gb18030("\u{E4C5}", b"\xFE\xFE");
+        }
 
         // The difference from the original GB18030
         encode_gb18030("\u{E5E5}", b"&#58853;");
@@ -667,9 +669,11 @@ mod tests {
         // Four bytes
         encode_gb18030("\u{0080}", b"\x81\x30\x81\x30");
         encode_gb18030("\u{E7C7}", b"\x81\x35\xF4\x37");
-        encode_gb18030("\u{2603}", b"\x81\x37\xA3\x30");
-        encode_gb18030("\u{1F4A9}", b"\x94\x39\xDA\x33");
-        encode_gb18030("\u{10FFFF}", b"\xE3\x32\x9A\x35");
+        if !cfg!(miri) { // Miri is too slow
+            encode_gb18030("\u{2603}", b"\x81\x37\xA3\x30");
+            encode_gb18030("\u{1F4A9}", b"\x94\x39\xDA\x33");
+            encode_gb18030("\u{10FFFF}", b"\xE3\x32\x9A\x35");
+        }
 
         // Edge cases
         encode_gb18030("\u{00F7}", b"\xA1\xC2");
@@ -689,12 +693,14 @@ mod tests {
         // two bytes
         encode_gbk("\u{4E02}", b"\x81\x40");
         encode_gbk("\u{4E8A}", b"\x81\x7E");
-        encode_gbk("\u{4E90}", b"\x81\x80");
-        encode_gbk("\u{4FA2}", b"\x81\xFE");
-        encode_gbk("\u{FA0C}", b"\xFE\x40");
-        encode_gbk("\u{E843}", b"\xFE\x7E");
-        encode_gbk("\u{4723}", b"\xFE\x80");
-        encode_gbk("\u{E4C5}", b"\xFE\xFE");
+        if !cfg!(miri) { // Miri is too slow
+            encode_gbk("\u{4E90}", b"\x81\x80");
+            encode_gbk("\u{4FA2}", b"\x81\xFE");
+            encode_gbk("\u{FA0C}", b"\xFE\x40");
+            encode_gbk("\u{E843}", b"\xFE\x7E");
+            encode_gbk("\u{4723}", b"\xFE\x80");
+            encode_gbk("\u{E4C5}", b"\xFE\xFE");
+        }
 
         // The difference from the original gb18030
         encode_gbk("\u{E5E5}", b"&#58853;");
@@ -703,15 +709,18 @@ mod tests {
         // Four bytes
         encode_gbk("\u{0080}", b"&#128;");
         encode_gbk("\u{E7C7}", b"&#59335;");
-        encode_gbk("\u{2603}", b"&#9731;");
-        encode_gbk("\u{1F4A9}", b"&#128169;");
-        encode_gbk("\u{10FFFF}", b"&#1114111;");
+        if !cfg!(miri) { // Miri is too slow
+            encode_gbk("\u{2603}", b"&#9731;");
+            encode_gbk("\u{1F4A9}", b"&#128169;");
+            encode_gbk("\u{10FFFF}", b"&#1114111;");
+        }
 
         // Edge cases
         encode_gbk("\u{00F7}", b"\xA1\xC2");
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_gb18030_decode_all() {
         let input = include_bytes!("test_data/gb18030_in.txt");
         let expectation = include_str!("test_data/gb18030_in_ref.txt");
@@ -721,6 +730,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_gb18030_encode_all() {
         let input = include_str!("test_data/gb18030_out.txt");
         let expectation = include_bytes!("test_data/gb18030_out_ref.txt");

--- a/src/iso_2022_jp.rs
+++ b/src/iso_2022_jp.rs
@@ -863,6 +863,10 @@ mod tests {
         decode_iso_2022_jp(b"\x1B$@\x80\x54\x64", "\u{FFFD}\u{58FA}");
         decode_iso_2022_jp(b"\x1B$B\x28\x80", "\u{FFFD}");
 
+        if cfg!(miri) { // Miri is too slow
+            return;
+        }
+
         // Transitions
         decode_iso_2022_jp(b"\x1B(B\x5C\x1B(J\x5C", "\u{005C}\u{00A5}");
         decode_iso_2022_jp(b"\x1B(B\x5C\x1B(I\x21", "\u{005C}\u{FF61}");
@@ -938,35 +942,42 @@ mod tests {
         // Roman
         encode_iso_2022_jp("a\u{00A5}b", b"a\x1B(J\x5Cb\x1B(B");
         encode_iso_2022_jp("a\u{203E}b", b"a\x1B(J\x7Eb\x1B(B");
-        encode_iso_2022_jp("a\u{00A5}b\x5C", b"a\x1B(J\x5Cb\x1B(B\x5C");
-        encode_iso_2022_jp("a\u{203E}b\x7E", b"a\x1B(J\x7Eb\x1B(B\x7E");
-        encode_iso_2022_jp("\u{00A5}\u{1F4A9}", b"\x1B(J\x5C&#128169;\x1B(B");
-        encode_iso_2022_jp("\u{00A5}\x1B", b"\x1B(J\x5C&#65533;\x1B(B");
-        encode_iso_2022_jp("\u{00A5}\x0E", b"\x1B(J\x5C&#65533;\x1B(B");
-        encode_iso_2022_jp("\u{00A5}\x0F", b"\x1B(J\x5C&#65533;\x1B(B");
-        encode_iso_2022_jp("\u{00A5}\u{58FA}", b"\x1B(J\x5C\x1B$B\x54\x64\x1B(B");
+        if !cfg!(miri) { // Miri is too slow
+            encode_iso_2022_jp("a\u{00A5}b\x5C", b"a\x1B(J\x5Cb\x1B(B\x5C");
+            encode_iso_2022_jp("a\u{203E}b\x7E", b"a\x1B(J\x7Eb\x1B(B\x7E");
+            encode_iso_2022_jp("\u{00A5}\u{1F4A9}", b"\x1B(J\x5C&#128169;\x1B(B");
+            encode_iso_2022_jp("\u{00A5}\x1B", b"\x1B(J\x5C&#65533;\x1B(B");
+            encode_iso_2022_jp("\u{00A5}\x0E", b"\x1B(J\x5C&#65533;\x1B(B");
+            encode_iso_2022_jp("\u{00A5}\x0F", b"\x1B(J\x5C&#65533;\x1B(B");
+            encode_iso_2022_jp("\u{00A5}\u{58FA}", b"\x1B(J\x5C\x1B$B\x54\x64\x1B(B");
+        }
 
         // Half-width Katakana
         encode_iso_2022_jp("\u{FF61}", b"\x1B$B\x21\x23\x1B(B");
         encode_iso_2022_jp("\u{FF65}", b"\x1B$B\x21\x26\x1B(B");
-        encode_iso_2022_jp("\u{FF66}", b"\x1B$B\x25\x72\x1B(B");
-        encode_iso_2022_jp("\u{FF70}", b"\x1B$B\x21\x3C\x1B(B");
-        encode_iso_2022_jp("\u{FF9D}", b"\x1B$B\x25\x73\x1B(B");
-        encode_iso_2022_jp("\u{FF9E}", b"\x1B$B\x21\x2B\x1B(B");
-        encode_iso_2022_jp("\u{FF9F}", b"\x1B$B\x21\x2C\x1B(B");
+        if !cfg!(miri) { // Miri is too slow
+            encode_iso_2022_jp("\u{FF66}", b"\x1B$B\x25\x72\x1B(B");
+            encode_iso_2022_jp("\u{FF70}", b"\x1B$B\x21\x3C\x1B(B");
+            encode_iso_2022_jp("\u{FF9D}", b"\x1B$B\x25\x73\x1B(B");
+            encode_iso_2022_jp("\u{FF9E}", b"\x1B$B\x21\x2B\x1B(B");
+            encode_iso_2022_jp("\u{FF9F}", b"\x1B$B\x21\x2C\x1B(B");
+        }
 
         // 0208
         encode_iso_2022_jp("\u{58FA}", b"\x1B$B\x54\x64\x1B(B");
         encode_iso_2022_jp("\u{58FA}\u{250F}", b"\x1B$B\x54\x64\x28\x2E\x1B(B");
-        encode_iso_2022_jp("\u{58FA}\u{1F4A9}", b"\x1B$B\x54\x64\x1B(B&#128169;");
-        encode_iso_2022_jp("\u{58FA}\x1B", b"\x1B$B\x54\x64\x1B(B&#65533;");
-        encode_iso_2022_jp("\u{58FA}\x0E", b"\x1B$B\x54\x64\x1B(B&#65533;");
-        encode_iso_2022_jp("\u{58FA}\x0F", b"\x1B$B\x54\x64\x1B(B&#65533;");
-        encode_iso_2022_jp("\u{58FA}\u{00A5}", b"\x1B$B\x54\x64\x1B(J\x5C\x1B(B");
-        encode_iso_2022_jp("\u{58FA}a", b"\x1B$B\x54\x64\x1B(Ba");
+        if !cfg!(miri) { // Miri is too slow
+            encode_iso_2022_jp("\u{58FA}\u{1F4A9}", b"\x1B$B\x54\x64\x1B(B&#128169;");
+            encode_iso_2022_jp("\u{58FA}\x1B", b"\x1B$B\x54\x64\x1B(B&#65533;");
+            encode_iso_2022_jp("\u{58FA}\x0E", b"\x1B$B\x54\x64\x1B(B&#65533;");
+            encode_iso_2022_jp("\u{58FA}\x0F", b"\x1B$B\x54\x64\x1B(B&#65533;");
+            encode_iso_2022_jp("\u{58FA}\u{00A5}", b"\x1B$B\x54\x64\x1B(J\x5C\x1B(B");
+            encode_iso_2022_jp("\u{58FA}a", b"\x1B$B\x54\x64\x1B(Ba");
+        }
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_iso_2022_jp_decode_all() {
         let input = include_bytes!("test_data/iso_2022_jp_in.txt");
         let expectation = include_str!("test_data/iso_2022_jp_in_ref.txt");
@@ -976,6 +987,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_iso_2022_jp_encode_all() {
         let input = include_str!("test_data/iso_2022_jp_out.txt");
         let expectation = include_bytes!("test_data/iso_2022_jp_out_ref.txt");

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -2231,8 +2231,9 @@ mod tests {
 
     #[test]
     fn test_is_utf16_latin1_fail() {
-        let mut src: Vec<u16> = Vec::with_capacity(256);
-        src.resize(256, 0);
+        let len = if cfg!(miri) { 64 } else { 256 }; // Miri is too slow
+        let mut src: Vec<u16> = Vec::with_capacity(len);
+        src.resize(len, 0);
         for i in 0..src.len() {
             src[i] = i as u16;
         }
@@ -2248,8 +2249,9 @@ mod tests {
 
     #[test]
     fn test_is_str_latin1_success() {
-        let mut src: Vec<u16> = Vec::with_capacity(256);
-        src.resize(256, 0);
+        let len = if cfg!(miri) { 64 } else { 256 }; // Miri is too slow
+        let mut src: Vec<u16> = Vec::with_capacity(len);
+        src.resize(len, 0);
         for i in 0..src.len() {
             src[i] = i as u16;
         }
@@ -2262,8 +2264,9 @@ mod tests {
 
     #[test]
     fn test_is_str_latin1_fail() {
-        let mut src: Vec<u16> = Vec::with_capacity(256);
-        src.resize(256, 0);
+        let len = if cfg!(miri) { 32 } else { 256 }; // Miri is too slow
+        let mut src: Vec<u16> = Vec::with_capacity(len);
+        src.resize(len, 0);
         for i in 0..src.len() {
             src[i] = i as u16;
         }
@@ -2280,8 +2283,9 @@ mod tests {
 
     #[test]
     fn test_is_utf8_latin1_success() {
-        let mut src: Vec<u16> = Vec::with_capacity(256);
-        src.resize(256, 0);
+        let len = if cfg!(miri) { 64 } else { 256 }; // Miri is too slow
+        let mut src: Vec<u16> = Vec::with_capacity(len);
+        src.resize(len, 0);
         for i in 0..src.len() {
             src[i] = i as u16;
         }
@@ -2297,8 +2301,9 @@ mod tests {
 
     #[test]
     fn test_is_utf8_latin1_fail() {
-        let mut src: Vec<u16> = Vec::with_capacity(256);
-        src.resize(256, 0);
+        let len = if cfg!(miri) { 32 } else { 256 }; // Miri is too slow
+        let mut src: Vec<u16> = Vec::with_capacity(len);
+        src.resize(len, 0);
         for i in 0..src.len() {
             src[i] = i as u16;
         }
@@ -3144,6 +3149,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_is_char_bidi_thoroughly() {
         for i in 0..0xD800u32 {
             let c: char = ::std::char::from_u32(i).unwrap();
@@ -3156,6 +3162,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_is_utf16_code_unit_bidi_thoroughly() {
         for i in 0..0x10000u32 {
             let u = i as u16;
@@ -3167,6 +3174,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_is_str_bidi_thoroughly() {
         let mut buf = [0; 4];
         for i in 0..0xD800u32 {
@@ -3186,6 +3194,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_is_utf8_bidi_thoroughly() {
         let mut buf = [0; 8];
         for i in 0..0xD800u32 {
@@ -3227,6 +3236,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_is_utf16_bidi_thoroughly() {
         let mut buf = [0; 32];
         for i in 0..0x10000u32 {

--- a/src/shift_jis.rs
+++ b/src/shift_jis.rs
@@ -385,6 +385,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_shift_jis_decode_all() {
         let input = include_bytes!("test_data/shift_jis_in.txt");
         let expectation = include_str!("test_data/shift_jis_in_ref.txt");
@@ -394,6 +395,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow
     fn test_shift_jis_encode_all() {
         let input = include_str!("test_data/shift_jis_out.txt");
         let expectation = include_bytes!("test_data/shift_jis_out_ref.txt");

--- a/src/single_byte.rs
+++ b/src/single_byte.rs
@@ -645,7 +645,10 @@ mod tests {
     fn test_single_byte_decode() {
         decode_single_byte(IBM866, &data::SINGLE_BYTE_DATA.ibm866);
         decode_single_byte(ISO_8859_10, &data::SINGLE_BYTE_DATA.iso_8859_10);
-        if cfg!(miri) { return; } // Miri is too slow
+        if cfg!(miri) {
+            // Miri is too slow
+            return;
+        }
         decode_single_byte(ISO_8859_13, &data::SINGLE_BYTE_DATA.iso_8859_13);
         decode_single_byte(ISO_8859_14, &data::SINGLE_BYTE_DATA.iso_8859_14);
         decode_single_byte(ISO_8859_15, &data::SINGLE_BYTE_DATA.iso_8859_15);
@@ -677,7 +680,10 @@ mod tests {
     fn test_single_byte_encode() {
         encode_single_byte(IBM866, &data::SINGLE_BYTE_DATA.ibm866);
         encode_single_byte(ISO_8859_10, &data::SINGLE_BYTE_DATA.iso_8859_10);
-        if cfg!(miri) { return; } // Miri is too slow
+        if cfg!(miri) {
+            // Miri is too slow
+            return;
+        }
         encode_single_byte(ISO_8859_13, &data::SINGLE_BYTE_DATA.iso_8859_13);
         encode_single_byte(ISO_8859_14, &data::SINGLE_BYTE_DATA.iso_8859_14);
         encode_single_byte(ISO_8859_15, &data::SINGLE_BYTE_DATA.iso_8859_15);

--- a/src/single_byte.rs
+++ b/src/single_byte.rs
@@ -645,6 +645,7 @@ mod tests {
     fn test_single_byte_decode() {
         decode_single_byte(IBM866, &data::SINGLE_BYTE_DATA.ibm866);
         decode_single_byte(ISO_8859_10, &data::SINGLE_BYTE_DATA.iso_8859_10);
+        if cfg!(miri) { return; } // Miri is too slow
         decode_single_byte(ISO_8859_13, &data::SINGLE_BYTE_DATA.iso_8859_13);
         decode_single_byte(ISO_8859_14, &data::SINGLE_BYTE_DATA.iso_8859_14);
         decode_single_byte(ISO_8859_15, &data::SINGLE_BYTE_DATA.iso_8859_15);
@@ -676,6 +677,7 @@ mod tests {
     fn test_single_byte_encode() {
         encode_single_byte(IBM866, &data::SINGLE_BYTE_DATA.ibm866);
         encode_single_byte(ISO_8859_10, &data::SINGLE_BYTE_DATA.iso_8859_10);
+        if cfg!(miri) { return; } // Miri is too slow
         encode_single_byte(ISO_8859_13, &data::SINGLE_BYTE_DATA.iso_8859_13);
         encode_single_byte(ISO_8859_14, &data::SINGLE_BYTE_DATA.iso_8859_14);
         encode_single_byte(ISO_8859_15, &data::SINGLE_BYTE_DATA.iso_8859_15);

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -12,7 +12,8 @@ use super::*;
 pub fn decode(encoding: &'static Encoding, bytes: &[u8], expect: &str) {
     let mut vec = Vec::with_capacity(bytes.len() + 32);
     let mut string = String::with_capacity(expect.len() + 32);
-    for i in 0usize..32usize {
+    let range = if cfg!(miri) { 0usize..4usize } else { 0usize..32usize };
+    for i in range {
         vec.clear();
         string.clear();
         for j in 0usize..i {
@@ -44,7 +45,8 @@ fn decode_without_padding_impl(
 pub fn encode(encoding: &'static Encoding, str: &str, expect: &[u8]) {
     let mut vec = Vec::with_capacity(expect.len() + 32);
     let mut string = String::with_capacity(str.len() + 32);
-    for i in 0usize..32usize {
+    let range = if cfg!(miri) { 0usize..4usize } else { 0usize..32usize };
+    for i in range {
         vec.clear();
         string.clear();
         for j in 0usize..i {


### PR DESCRIPTION
This patch makes `cargo miri test` complete in reasonable time for me (around 10min). However this takes around 7GB of RAM. By adding `-Zmiri-disable-stacked-borrows`, the RAM usage goes down to <1GB and the time to around 5min.

If you want, I can also hook this up to CI.