### PR TITLE
fix cargo miri flag passing

### DIFF
--- a/ci/miri.sh
+++ b/ci/miri.sh
@@ -8,7 +8,7 @@ rustup component add miri
 
 # Run tests.
 # Stacked Borrows is disabled as it costs too much RAM (due to our large tables).
-cargo miri test -- -Zmiri-disable-stacked-borrows
+MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo miri test
 
 # Restore old state in case Travis uses this cache for other jobs.
 rustup default nightly


### PR DESCRIPTION
`cargo miri test` changed to be more compatible with `cargo test`, but this means we had to find a different way to pass flags to the interpreter, so there now is a `MIRIFLAGS` environment variable for that. The old way currently still works but is deprecated. This updates CI here to the new way.