### PR TITLE
Use packed_simd_2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ fast-legacy-encode = ["fast-hangul-encode",
 
 [dependencies]
 cfg-if = "0.1.0"
-packed_simd = { version = "0.3.3", optional = true }
+packed_simd = { version = "0.3.4", package = "packed_simd_2", optional = true }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This updates packed_simd to 0.3.4, which is sadly only available on the packed_simd_2 crate (more on that at https://github.com/rust-lang/packed_simd/issues/298). It fixes compilation with the simd-accel feature on recent nightly toolchains.