### PR TITLE
Update cfg-if to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ fast-legacy-encode = ["fast-hangul-encode",
                       "fast-big5-hanzi-encode"]
 
 [dependencies]
-cfg-if = "0.1.0"
+cfg-if = "1.0"
 packed_simd = { version = "0.3.4", package = "packed_simd_2", optional = true }
 serde = { version = "1.0", optional = true }
 


### PR DESCRIPTION
This removes a duplicate dependency for ripgrep; see https://github.com/BurntSushi/ripgrep/pull/1705#issuecomment-709620097.