### PR TITLE
Add doc test for Encoding::for_label

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2697,6 +2697,20 @@ impl Encoding {
     /// on it.)
     ///
     /// Available via the C wrapper.
+    /// 
+    /// # Example
+    /// ```
+    /// use encoding_rs::Encoding;
+    /// 
+    /// assert_eq!(Some(encoding_rs::UTF_8), Encoding::for_label(b"utf-8"));
+    /// assert_eq!(Some(encoding_rs::UTF_8), Encoding::for_label(b"unicode11utf8"));
+    /// 
+    /// assert_eq!(Some(encoding_rs::ISO_8859_2), Encoding::for_label(b"latin2"));
+    /// 
+    /// assert_eq!(Some(encoding_rs::UTF_16BE), Encoding::for_label(b"utf-16be"));
+    /// 
+    /// assert_eq!(None, Encoding::for_label(b"unrecognized label"));
+    /// ```
     pub fn for_label(label: &[u8]) -> Option<&'static Encoding> {
         let mut trimmed = [0u8; LONGEST_LABEL_LENGTH];
         let mut trimmed_pos = 0usize;


### PR DESCRIPTION
I added a small doc test to the `Encoding::for_label` method.
The documentation was a bit unclear to me when I first tried to use this function. I tried to pass in my entire input and thought it would try to auto-detect its encoding.
Referring to the `get an encoding` algorithm made the function seem more sophisticated than it actually is.

With the example, I hope it becomes more clear what you are supposed to feed into the function.

(Also I'm still unsure what the difference between this method and the `no_replacement` version is. I would have expected that the `for_label` method cannot fail and chooses a fallback encoding instead, while the `for_label_no_replacement` returns an `Option` on error. Obviously this is not the case and I don't understand what the docs are trying to explain.)