### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/handles.rs
+++ b/src/handles.rs
@@ -111,8 +111,8 @@ impl UnalignedU16Slice {
         use core::mem::MaybeUninit;
 
         assert!(i < self.len);
+        let mut u: MaybeUninit<u16> = MaybeUninit::uninit();
         unsafe {
-            let mut u: MaybeUninit<u16> = MaybeUninit::uninit();
             ::core::ptr::copy_nonoverlapping(self.ptr.add(i * 2), u.as_mut_ptr() as *mut u8, 2);
             u.assume_init()
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4029,16 +4029,16 @@ impl Decoder {
         dst: &mut String,
         last: bool,
     ) -> (CoderResult, usize, bool) {
-        unsafe {
-            let vec = dst.as_mut_vec();
+        
+            let vec = unsafe {dst.as_mut_vec()};
             let old_len = vec.len();
             let capacity = vec.capacity();
-            vec.set_len(capacity);
+            unsafe {vec.set_len(capacity)};
             let (result, read, written, replaced) =
                 self.decode_to_utf8(src, &mut vec[old_len..], last);
-            vec.set_len(old_len + written);
+            unsafe {vec.set_len(old_len + written)};
             (result, read, replaced)
-        }
+        
     }
 
     public_decode_function!(/// Incrementally decode a byte stream into UTF-8
@@ -4119,16 +4119,16 @@ impl Decoder {
         dst: &mut String,
         last: bool,
     ) -> (DecoderResult, usize) {
-        unsafe {
-            let vec = dst.as_mut_vec();
+        
+            let vec = unsafe {dst.as_mut_vec()};
             let old_len = vec.len();
             let capacity = vec.capacity();
-            vec.set_len(capacity);
+            unsafe {vec.set_len(capacity)};
             let (result, read, written) =
                 self.decode_to_utf8_without_replacement(src, &mut vec[old_len..], last);
-            vec.set_len(old_len + written);
+            unsafe {vec.set_len(old_len + written)};
             (result, read)
-        }
+        
     }
 
     /// Query the worst-case UTF-16 output size (with or without replacement).
@@ -4620,15 +4620,15 @@ impl Encoder {
         dst: &mut Vec<u8>,
         last: bool,
     ) -> (CoderResult, usize, bool) {
-        unsafe {
+        
             let old_len = dst.len();
             let capacity = dst.capacity();
-            dst.set_len(capacity);
+            unsafe {dst.set_len(capacity)};
             let (result, read, written, replaced) =
                 self.encode_from_utf8(src, &mut dst[old_len..], last);
-            dst.set_len(old_len + written);
+            unsafe {dst.set_len(old_len + written)};
             (result, read, replaced)
-        }
+        
     }
 
     /// Incrementally encode into byte stream from UTF-8 _without replacement_.
@@ -4660,15 +4660,15 @@ impl Encoder {
         dst: &mut Vec<u8>,
         last: bool,
     ) -> (EncoderResult, usize) {
-        unsafe {
+        
             let old_len = dst.len();
             let capacity = dst.capacity();
-            dst.set_len(capacity);
+            unsafe {dst.set_len(capacity)};
             let (result, read, written) =
                 self.encode_from_utf8_without_replacement(src, &mut dst[old_len..], last);
-            dst.set_len(old_len + written);
+            unsafe {dst.set_len(old_len + written)};
             (result, read)
-        }
+        
     }
 
     /// Query the worst-case output size when encoding from UTF-16 with


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. However, I found that only 2 functions are real unsafe operations (see the list below).

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.
**Real unsafe operation list:**
1. the set_len()\as_mut_vec() function(these are unsafe functions)

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html
