### PR TITLE
MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://docs.rs/encoding_rs/"
 repository = "https://github.com/hsivonen/encoding_rs"
 keywords = ["encoding", "web", "unicode", "charset"]
 categories = ["text-processing", "encoding", "web-programming", "internationalization"]
-rust-version = "1.36"
+rust-version = "1.40"
 
 [features]
 default = ["alloc"]

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ as semver-breaking, because this crate depends on `cfg-if`, which doesn't
 appear to treat MSRV changes as semver-breaking, so it would be useless for
 this crate to treat MSRV changes as semver-breaking.
 
-As of 2024-04-04, MSRV appears to be Rust 1.36.0 for using the crate and
+As of 2024-11-01, MSRV appears to be Rust 1.40.0 for using the crate and
 1.42.0 for doc tests to pass without errors about the global allocator.
 With the `simd-accel` feature, the MSRV is even higher.
 

--- a/src/iso_2022_jp.rs
+++ b/src/iso_2022_jp.rs
@@ -373,7 +373,7 @@ fn is_kanji_mapped(bmp: u16) -> bool {
 }
 
 #[cfg(not(feature = "fast-kanji-encode"))]
-#[allow(clippy::if_let_redundant_pattern_matching, clippy::if_same_then_else)]
+#[allow(clippy::redundant_pattern_matching, clippy::if_same_then_else)]
 #[inline(always)]
 fn is_kanji_mapped(bmp: u16) -> bool {
     if 0x4EDD == bmp {
@@ -391,7 +391,7 @@ fn is_kanji_mapped(bmp: u16) -> bool {
     }
 }
 
-#[allow(clippy::if_let_redundant_pattern_matching, clippy::if_same_then_else)]
+#[allow(clippy::redundant_pattern_matching, clippy::if_same_then_else)]
 fn is_mapped_for_two_byte_encode(bmp: u16) -> bool {
     // The code below uses else after return to
     // keep the same structure as in EUC-JP.


### PR DESCRIPTION
I haven't noticed that in my previous PR `core::mem::take` bumped MSRV to 1.40. This is still [super old](https://lib.rs/stats#rustc), so shouldn't cause any problems.

