### PR TITLE
Tests

### DIFF
--- a/src/simd_funcs.rs
+++ b/src/simd_funcs.rs
@@ -349,6 +349,7 @@ cfg_if! {
 }
 
 #[cfg(test)]
+#[cfg(feature = "alloc")]
 mod tests {
     use super::*;
     use alloc::vec::Vec;

--- a/tests/test_data.rs
+++ b/tests/test_data.rs
@@ -1,0 +1,8 @@
+mod test_data {
+    mod big5;
+    mod euc_jp;
+    mod euc_kr;
+    mod gb18030;
+    mod iso_2022_jp;
+    mod shift_jis;
+}

--- a/tests/test_data.rs
+++ b/tests/test_data.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "alloc")]
 mod test_data {
     mod big5;
     mod euc_jp;

--- a/tests/test_data/big5.rs
+++ b/tests/test_data/big5.rs
@@ -3,8 +3,8 @@ use encoding_rs::*;
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_big5_decode_all() {
-    let input = include_bytes!("test_data/big5_in.txt");
-    let expectation = include_str!("test_data/big5_in_ref.txt");
+    let input = include_bytes!("big5_in.txt");
+    let expectation = include_str!("big5_in_ref.txt");
     let (cow, had_errors) = BIG5.decode_without_bom_handling(input);
     assert!(had_errors, "Should have had errors.");
     assert_eq!(&cow[..], expectation);
@@ -13,8 +13,8 @@ fn test_big5_decode_all() {
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_big5_encode_all() {
-    let input = include_str!("test_data/big5_out.txt");
-    let expectation = include_bytes!("test_data/big5_out_ref.txt");
+    let input = include_str!("big5_out.txt");
+    let expectation = include_bytes!("big5_out_ref.txt");
     let (cow, encoding, had_errors) = BIG5.encode(input);
     assert!(!had_errors, "Should not have had errors.");
     assert_eq!(encoding, BIG5);

--- a/tests/test_data/euc_jp.rs
+++ b/tests/test_data/euc_jp.rs
@@ -3,8 +3,8 @@ use encoding_rs::*;
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_jis0208_decode_all() {
-    let input = include_bytes!("test_data/jis0208_in.txt");
-    let expectation = include_str!("test_data/jis0208_in_ref.txt");
+    let input = include_bytes!("jis0208_in.txt");
+    let expectation = include_str!("jis0208_in_ref.txt");
     let (cow, had_errors) = EUC_JP.decode_without_bom_handling(input);
     assert!(had_errors, "Should have had errors.");
     assert_eq!(&cow[..], expectation);
@@ -13,8 +13,8 @@ fn test_jis0208_decode_all() {
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_jis0208_encode_all() {
-    let input = include_str!("test_data/jis0208_out.txt");
-    let expectation = include_bytes!("test_data/jis0208_out_ref.txt");
+    let input = include_str!("jis0208_out.txt");
+    let expectation = include_bytes!("jis0208_out_ref.txt");
     let (cow, encoding, had_errors) = EUC_JP.encode(input);
     assert!(!had_errors, "Should not have had errors.");
     assert_eq!(encoding, EUC_JP);
@@ -24,8 +24,8 @@ fn test_jis0208_encode_all() {
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_jis0212_decode_all() {
-    let input = include_bytes!("test_data/jis0212_in.txt");
-    let expectation = include_str!("test_data/jis0212_in_ref.txt");
+    let input = include_bytes!("jis0212_in.txt");
+    let expectation = include_str!("jis0212_in_ref.txt");
     let (cow, had_errors) = EUC_JP.decode_without_bom_handling(input);
     assert!(had_errors, "Should have had errors.");
     assert_eq!(&cow[..], expectation);

--- a/tests/test_data/euc_kr.rs
+++ b/tests/test_data/euc_kr.rs
@@ -3,8 +3,8 @@ use encoding_rs::*;
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_euc_kr_decode_all() {
-    let input = include_bytes!("test_data/euc_kr_in.txt");
-    let expectation = include_str!("test_data/euc_kr_in_ref.txt");
+    let input = include_bytes!("euc_kr_in.txt");
+    let expectation = include_str!("euc_kr_in_ref.txt");
     let (cow, had_errors) = EUC_KR.decode_without_bom_handling(input);
     assert!(had_errors, "Should have had errors.");
     assert_eq!(&cow[..], expectation);
@@ -13,8 +13,8 @@ fn test_euc_kr_decode_all() {
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_euc_kr_encode_all() {
-    let input = include_str!("test_data/euc_kr_out.txt");
-    let expectation = include_bytes!("test_data/euc_kr_out_ref.txt");
+    let input = include_str!("euc_kr_out.txt");
+    let expectation = include_bytes!("euc_kr_out_ref.txt");
     let (cow, encoding, had_errors) = EUC_KR.encode(input);
     assert!(!had_errors, "Should not have had errors.");
     assert_eq!(encoding, EUC_KR);

--- a/tests/test_data/gb18030.rs
+++ b/tests/test_data/gb18030.rs
@@ -3,8 +3,8 @@ use encoding_rs::*;
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_gb18030_decode_all() {
-    let input = include_bytes!("test_data/gb18030_in.txt");
-    let expectation = include_str!("test_data/gb18030_in_ref.txt");
+    let input = include_bytes!("gb18030_in.txt");
+    let expectation = include_str!("gb18030_in_ref.txt");
     let (cow, had_errors) = GB18030.decode_without_bom_handling(input);
     assert!(!had_errors, "Should not have had errors.");
     assert_eq!(&cow[..], expectation);
@@ -13,8 +13,8 @@ fn test_gb18030_decode_all() {
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_gb18030_encode_all() {
-    let input = include_str!("test_data/gb18030_out.txt");
-    let expectation = include_bytes!("test_data/gb18030_out_ref.txt");
+    let input = include_str!("gb18030_out.txt");
+    let expectation = include_bytes!("gb18030_out_ref.txt");
     let (cow, encoding, had_errors) = GB18030.encode(input);
     assert!(!had_errors, "Should not have had errors.");
     assert_eq!(encoding, GB18030);

--- a/tests/test_data/iso_2022_jp.rs
+++ b/tests/test_data/iso_2022_jp.rs
@@ -3,8 +3,8 @@ use encoding_rs::*;
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_iso_2022_jp_decode_all() {
-    let input = include_bytes!("test_data/iso_2022_jp_in.txt");
-    let expectation = include_str!("test_data/iso_2022_jp_in_ref.txt");
+    let input = include_bytes!("iso_2022_jp_in.txt");
+    let expectation = include_str!("iso_2022_jp_in_ref.txt");
     let (cow, had_errors) = ISO_2022_JP.decode_without_bom_handling(input);
     assert!(had_errors, "Should have had errors.");
     assert_eq!(&cow[..], expectation);
@@ -13,8 +13,8 @@ fn test_iso_2022_jp_decode_all() {
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_iso_2022_jp_encode_all() {
-    let input = include_str!("test_data/iso_2022_jp_out.txt");
-    let expectation = include_bytes!("test_data/iso_2022_jp_out_ref.txt");
+    let input = include_str!("iso_2022_jp_out.txt");
+    let expectation = include_bytes!("iso_2022_jp_out_ref.txt");
     let (cow, encoding, had_errors) = ISO_2022_JP.encode(input);
     assert!(!had_errors, "Should not have had errors.");
     assert_eq!(encoding, ISO_2022_JP);

--- a/tests/test_data/shift_jis.rs
+++ b/tests/test_data/shift_jis.rs
@@ -3,8 +3,8 @@ use encoding_rs::*;
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_shift_jis_decode_all() {
-    let input = include_bytes!("test_data/shift_jis_in.txt");
-    let expectation = include_str!("test_data/shift_jis_in_ref.txt");
+    let input = include_bytes!("shift_jis_in.txt");
+    let expectation = include_str!("shift_jis_in_ref.txt");
     let (cow, had_errors) = SHIFT_JIS.decode_without_bom_handling(input);
     assert!(had_errors, "Should have had errors.");
     assert_eq!(&cow[..], expectation);
@@ -13,8 +13,8 @@ fn test_shift_jis_decode_all() {
 #[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_shift_jis_encode_all() {
-    let input = include_str!("test_data/shift_jis_out.txt");
-    let expectation = include_bytes!("test_data/shift_jis_out_ref.txt");
+    let input = include_str!("shift_jis_out.txt");
+    let expectation = include_bytes!("shift_jis_out_ref.txt");
     let (cow, encoding, had_errors) = SHIFT_JIS.encode(input);
     assert!(!had_errors, "Should not have had errors.");
     assert_eq!(encoding, SHIFT_JIS);


### PR DESCRIPTION
Tests loaded as modules can run in parallel, which makes `cargo +nightly hack test --each-feature` quicker. Which BTW discovered that some tests require the `alloc` feature.