### PR TITLE
Keep old_pos only where necessary

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -258,8 +258,9 @@ macro_rules! ascii_compatible_two_byte_decoder_function {
                                                             }
                                                             Space::Available(destination_handle_again) => {
                                                                 {
-                                                                    let (b_again, _unread_handle_again) =
+                                                                    let (b_again, unread_handle_again) =
                                                                         source_handle_again.read();
+                                                                    unread_handle_again.commit();
                                                                     b = b_again;
                                                                     destination_handle = destination_handle_again;
                                                                     continue 'innermost;
@@ -570,7 +571,8 @@ macro_rules! gb18030_decoder_function {
                                                 dst_written);
                                     }
                                     Space::Available(destination_handle) => {
-                                        let (b, _) = source_handle.read();
+                                        let (b, unread_handle) = source_handle.read();
+                                        unread_handle.commit();
                                         loop {
                                             if b > 127 {
                                                 $non_ascii = b;
@@ -874,7 +876,8 @@ macro_rules! euc_jp_decoder_function {
                                                 dst_written);
                                     }
                                     Space::Available(destination_handle) => {
-                                        let (b, _) = source_handle.read();
+                                        let (b, unread_handle) = source_handle.read();
+                                        unread_handle.commit();
                                         loop {
                                             if b > 127 {
                                                 $non_ascii = b;
@@ -1139,8 +1142,9 @@ macro_rules! ascii_compatible_encoder_function {
                                                             }
                                                             Space::Available(destination_handle_again) => {
                                                                 {
-                                                                    let (c_again, _unread_handle_again) =
+                                                                    let (c_again, unread_handle_again) =
                                                                         source_handle_again.read_enum();
+                                                                    unread_handle_again.commit();
                                                                     c = c_again;
                                                                     destination_handle = destination_handle_again;
                                                                     continue 'innermost;

--- a/src/single_byte.rs
+++ b/src/single_byte.rs
@@ -120,8 +120,9 @@ impl SingleByteDecoder {
                                                         Space::Available(
                                                             destination_handle_again,
                                                         ) => {
-                                                            let (b_again, _unread_handle_again) =
+                                                            let (b_again, unread_handle_again) =
                                                                 source_handle_again.read();
+                                                            unread_handle_again.commit();
                                                             b = b_again;
                                                             destination_handle =
                                                                 destination_handle_again;

--- a/src/x_user_defined.rs
+++ b/src/x_user_defined.rs
@@ -49,6 +49,8 @@ impl UserDefinedDecoder {
         {},
         {},
         {
+            unread_handle.commit();
+
             if b < 0x80 {
                 // ASCII run not optimized, because binary data expected
                 destination_handle.write_ascii(b);
@@ -63,7 +65,7 @@ impl UserDefinedDecoder {
         source,
         b,
         destination_handle,
-        _unread_handle,
+        unread_handle,
         check_space_bmp,
         decode_to_utf8_raw,
         u8,


### PR DESCRIPTION
Keeps more commonly used types smaller, and without unrelated state.