### PR TITLE
Named args for macros

### DIFF
--- a/src/big5.rs
+++ b/src/big5.rs
@@ -74,7 +74,7 @@ impl Big5Decoder {
     }
 
     ascii_compatible_two_byte_decoder_functions!(
-        {
+        lead = {
             // If lead is between 0x81 and 0xFE, inclusive,
             // subtract offset 0x81.
             let non_ascii_minus_offset =
@@ -86,7 +86,7 @@ impl Big5Decoder {
             }
             non_ascii_minus_offset
         },
-        {
+        trail = {
             // If trail is between 0x40 and 0x7E, inclusive,
             // subtract offset 0x40. Else if trail is
             // between 0xA1 and 0xFE, inclusive, subtract
@@ -151,17 +151,17 @@ impl Big5Decoder {
                 handle.write_bmp_excl_ascii(low_bits)
             }
         },
-        self,
-        non_ascii,
-        byte,
-        lead_minus_offset,
-        unread_handle_trail,
-        source,
-        handle,
-        'outermost,
-        copy_ascii_from_check_space_astral,
-        check_space_astral,
-        false);
+        self = self,
+        non_ascii = non_ascii,
+        byte = byte,
+        lead_minus_offset = lead_minus_offset,
+        unread_handle_trail = unread_handle_trail,
+        source = source,
+        handle = handle,
+        outermost = 'outermost,
+        copy_ascii = copy_ascii_from_check_space_astral,
+        destination_check = check_space_astral,
+        ascii_punctuation = false);
 }
 
 pub struct Big5Encoder;

--- a/src/euc_kr.rs
+++ b/src/euc_kr.rs
@@ -50,7 +50,7 @@ impl EucKrDecoder {
     }
 
     ascii_compatible_two_byte_decoder_functions!(
-        {
+        lead = {
             // If lead is between 0x81 and 0xFE, inclusive,
             // subtract offset 0x81.
             let non_ascii_minus_offset =
@@ -62,7 +62,7 @@ impl EucKrDecoder {
             }
             non_ascii_minus_offset
         },
-        {
+        trail = {
             if lead_minus_offset >= 0x20 {
                 // Not the extension range above KS X 1001
                 let trail_minus_offset =
@@ -172,17 +172,17 @@ impl EucKrDecoder {
                 handle.write_upper_bmp(upper_bmp)
             }
         },
-        self,
-        non_ascii,
-        byte,
-        lead_minus_offset,
-        unread_handle_trail,
-        source,
-        handle,
-        'outermost,
-        copy_ascii_from_check_space_bmp,
-        check_space_bmp,
-        true);
+        self = self,
+        non_ascii = non_ascii,
+        byte = byte,
+        lead_minus_offset = lead_minus_offset,
+        unread_handle_trail = unread_handle_trail,
+        source = source,
+        handle = handle,
+        outermost = 'outermost,
+        copy_ascii = copy_ascii_from_check_space_bmp,
+        destination_check = check_space_bmp,
+        ascii_punctuation = true);
 }
 
 fn ksx1001_encode_misc(bmp: u16) -> Option<(usize, usize)> {

--- a/src/iso_2022_jp.rs
+++ b/src/iso_2022_jp.rs
@@ -517,7 +517,7 @@ impl Iso2022JpEncoder {
     }
 
     encoder_functions!(
-        {
+        eof = {
             match self.state {
                 Iso2022JpEncoderState::Ascii => {}
                 _ => match dest.check_space_three() {
@@ -531,7 +531,7 @@ impl Iso2022JpEncoder {
                 },
             }
         },
-        {
+        body = {
             match self.state {
                 Iso2022JpEncoderState::Ascii => {
                     if c == '\u{0E}' || c == '\u{0F}' || c == '\u{1B}' {
@@ -734,14 +734,14 @@ impl Iso2022JpEncoder {
                 }
             }
         },
-        self,
-        src_consumed,
-        source,
-        dest,
-        c,
-        destination_handle,
-        unread_handle,
-        check_space_three
+        self = self,
+        src_consumed = src_consumed,
+        source = source,
+        dest = dest,
+        c = c,
+        destination_handle = destination_handle,
+        unread_handle = unread_handle,
+        destination_check = check_space_three
     );
 }
 

--- a/src/iso_2022_jp.rs
+++ b/src/iso_2022_jp.rs
@@ -96,7 +96,7 @@ impl Iso2022JpDecoder {
     }
 
     decoder_functions!(
-        {
+        preamble = {
             if self.pending_prepended {
                 // lead was set in EscapeStart and "prepended"
                 // in Escape.
@@ -127,8 +127,8 @@ impl Iso2022JpDecoder {
                 }
             }
         },
-        {},
-        {
+        loop_preamble = {},
+        eof = {
             match self.decoder_state {
                 Iso2022JpDecoderState::TrailByte | Iso2022JpDecoderState::EscapeStart => {
                     self.decoder_state = self.output_state;
@@ -142,7 +142,7 @@ impl Iso2022JpDecoder {
                 _ => {}
             }
         },
-        {
+        body = {
             match self.decoder_state {
                 Iso2022JpDecoderState::Ascii => {
                     if b == 0x1Bu8 {
@@ -353,14 +353,14 @@ impl Iso2022JpDecoder {
                 }
             }
         },
-        self,
-        src_consumed,
-        dest,
-        source,
-        b,
-        destination_handle,
-        unread_handle,
-        check_space_bmp
+        self = self,
+        src_consumed = src_consumed,
+        dest = dest,
+        source = source,
+        byte = b,
+        destination_handle = destination_handle,
+        unread_handle = unread_handle,
+        destination_check = check_space_bmp
     );
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1010,16 +1010,16 @@ macro_rules! encoder_function {
 
 macro_rules! encoder_functions {
     (
-        $eof:block,
-        $body:block,
-        $slf:ident,
-        $src_consumed:ident,
-        $source:ident,
-        $dest:ident,
-        $c:ident,
-        $destination_handle:ident,
-        $unread_handle:ident,
-        $destination_check:ident
+        eof = $eof:block,
+        body = $body:block,
+        self = $slf:ident,
+        src_consumed = $src_consumed:ident,
+        source = $source:ident,
+        dest = $dest:ident,
+        c = $c:ident,
+        destination_handle = $destination_handle:ident,
+        unread_handle = $unread_handle:ident,
+        destination_check = $destination_check:ident
     ) => {
         encoder_function!(
             $eof,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,7 +9,7 @@
 
 macro_rules! decoder_function {
     ($preamble:block,
-     $loop_preable:block,
+     $loop_preamble:block,
      $eof:block,
      $body:block,
      $slf:ident,
@@ -38,7 +38,7 @@ macro_rules! decoder_function {
             }
             loop {
                 {
-                    $loop_preable
+                    $loop_preamble
                 }
                 match $source.check_available() {
                     Space::Full($src_consumed) => {
@@ -72,22 +72,22 @@ macro_rules! decoder_function {
 
 macro_rules! decoder_functions {
     (
-        $preamble:block,
-        $loop_preable:block,
-        $eof:block,
-        $body:block,
-        $slf:ident,
-        $src_consumed:ident,
-        $dest:ident,
-        $source:ident,
-        $b:ident,
-        $destination_handle:ident,
-        $unread_handle:ident,
-        $destination_check:ident
+        preamble = $preamble:block,
+        loop_preamble = $loop_preamble:block,
+        eof = $eof:block,
+        body = $body:block,
+        self = $slf:ident,
+        src_consumed = $src_consumed:ident,
+        dest = $dest:ident,
+        source = $source:ident,
+        byte = $b:ident,
+        destination_handle = $destination_handle:ident,
+        unread_handle = $unread_handle:ident,
+        destination_check = $destination_check:ident
     ) => {
         decoder_function!(
             $preamble,
-            $loop_preable,
+            $loop_preamble,
             $eof,
             $body,
             $slf,
@@ -104,7 +104,7 @@ macro_rules! decoder_functions {
         );
         decoder_function!(
             $preamble,
-            $loop_preable,
+            $loop_preamble,
             $eof,
             $body,
             $slf,
@@ -285,19 +285,19 @@ macro_rules! ascii_compatible_two_byte_decoder_function {
 
 macro_rules! ascii_compatible_two_byte_decoder_functions {
     (
-        $lead:block,
-        $trail:block,
-        $slf:ident,
-        $non_ascii:ident,
-        $byte:ident,
-        $lead_minus_offset:ident,
-        $unread_handle_trail:ident,
-        $source:ident,
-        $handle:ident,
-        $outermost:tt,
-        $copy_ascii:ident,
-        $destination_check:ident,
-        $ascii_punctuation:expr
+        lead = $lead:block,
+        trail = $trail:block,
+        self = $slf:ident,
+        non_ascii = $non_ascii:ident,
+        byte = $byte:ident,
+        lead_minus_offset = $lead_minus_offset:ident,
+        unread_handle_trail = $unread_handle_trail:ident,
+        source = $source:ident,
+        handle = $handle:ident,
+        outermost = $outermost:tt,
+        copy_ascii = $copy_ascii:ident,
+        destination_check = $destination_check:ident,
+        ascii_punctuation = $ascii_punctuation:expr
     ) => {
         ascii_compatible_two_byte_decoder_function!(
             $lead,

--- a/src/shift_jis.rs
+++ b/src/shift_jis.rs
@@ -49,7 +49,7 @@ impl ShiftJisDecoder {
     }
 
     ascii_compatible_two_byte_decoder_functions!(
-        {
+        lead = {
            // If lead is between 0x81 and 0x9F, inclusive,
            // subtract offset 0x81. Else if lead is
            // between 0xE0 and 0xFC, inclusive, subtract
@@ -80,7 +80,7 @@ impl ShiftJisDecoder {
             }
             non_ascii_minus_offset
         },
-        {
+        trail = {
             // If trail is between 0x40 and 0x7E, inclusive,
             // subtract offset 0x40. Else if trail is
             // between 0x80 and 0xFC, inclusive, subtract
@@ -158,17 +158,17 @@ impl ShiftJisDecoder {
                 }
             }
         },
-        self,
-        non_ascii,
-        byte,
-        lead_minus_offset,
-        unread_handle_trail,
-        source,
-        handle,
-        'outermost,
-        copy_ascii_from_check_space_bmp,
-        check_space_bmp,
-        false);
+        self = self,
+        non_ascii = non_ascii,
+        byte = byte,
+        lead_minus_offset = lead_minus_offset,
+        unread_handle_trail = unread_handle_trail,
+        source = source,
+        handle = handle,
+        outermost = 'outermost,
+        copy_ascii = copy_ascii_from_check_space_bmp,
+        destination_check = check_space_bmp,
+        ascii_punctuation = false);
 }
 
 #[cfg(feature = "fast-kanji-encode")]

--- a/src/utf_16.rs
+++ b/src/utf_16.rs
@@ -61,7 +61,7 @@ impl Utf16Decoder {
     }
 
     decoder_functions!(
-        {
+        preamble = {
             if self.pending_bmp {
                 match dest.check_space_bmp() {
                     Space::Full(_) => {
@@ -75,7 +75,7 @@ impl Utf16Decoder {
                 }
             }
         },
-        {
+        loop_preamble = {
             // This is the fast path. The rest runs only at the
             // start and end for partial sequences.
             if self.lead_byte.is_none() && self.lead_surrogate == 0 {
@@ -88,7 +88,7 @@ impl Utf16Decoder {
                 }
             }
         },
-        {
+        eof = {
             debug_assert!(!self.pending_bmp);
             if self.lead_surrogate != 0 || self.lead_byte.is_some() {
                 // We need to check space without intent to write in order to
@@ -125,7 +125,7 @@ impl Utf16Decoder {
                 }
             }
         },
-        {
+        body = {
             match self.lead_byte {
                 None => {
                     self.lead_byte = Some(b);
@@ -186,14 +186,14 @@ impl Utf16Decoder {
                 }
             }
         },
-        self,
-        src_consumed,
-        dest,
-        source,
-        b,
-        destination_handle,
-        unread_handle,
-        check_space_astral
+        self = self,
+        src_consumed = src_consumed,
+        dest = dest,
+        source = source,
+        byte = b,
+        destination_handle = destination_handle,
+        unread_handle = unread_handle,
+        destination_check = check_space_astral
     );
 }
 

--- a/src/utf_8.rs
+++ b/src/utf_8.rs
@@ -496,15 +496,15 @@ impl Utf8Decoder {
     }
 
     decoder_functions!(
-        {},
-        {
+        preamble = {},
+        loop_preamble = {
             // This is the fast path. The rest runs only at the
             // start and end for partial sequences.
             if self.bytes_needed == 0 {
                 dest.copy_utf8_up_to_invalid_from(&mut source);
             }
         },
-        {
+        eof = {
             if self.bytes_needed != 0 {
                 let bad_bytes = (self.bytes_seen + 1) as u8;
                 self.code_point = 0;
@@ -517,7 +517,7 @@ impl Utf8Decoder {
                 );
             }
         },
-        {
+        body = {
             if self.bytes_needed == 0 {
                 if b < 0x80u8 {
                     destination_handle.write_ascii(b);
@@ -592,14 +592,14 @@ impl Utf8Decoder {
             self.bytes_seen = 0;
             continue;
         },
-        self,
-        src_consumed,
-        dest,
-        source,
-        b,
-        destination_handle,
-        unread_handle,
-        check_space_astral
+        self = self,
+        src_consumed = src_consumed,
+        dest = dest,
+        source = source,
+        byte = b,
+        destination_handle = destination_handle,
+        unread_handle = unread_handle,
+        destination_check = check_space_astral
     );
 }
 

--- a/src/x_user_defined.rs
+++ b/src/x_user_defined.rs
@@ -171,8 +171,8 @@ impl UserDefinedEncoder {
     }
 
     encoder_functions!(
-        {},
-        {
+        eof = {},
+        body = {
             if c <= '\u{7F}' {
                 // TODO optimize ASCII run
                 destination_handle.write_one(c as u8);
@@ -188,14 +188,14 @@ impl UserDefinedEncoder {
             destination_handle.write_one((u32::from(c) - 0xF700) as u8);
             continue;
         },
-        self,
-        src_consumed,
-        source,
-        dest,
-        c,
-        destination_handle,
-        unread_handle,
-        check_space_one
+        self = self,
+        src_consumed = src_consumed,
+        source = source,
+        dest = dest,
+        c = c,
+        destination_handle = destination_handle,
+        unread_handle = unread_handle,
+        destination_check = check_space_one
     );
 }
 


### PR DESCRIPTION
These macros have too many arguments. Explicit argument names help describe what is what, and prevent specifying them in a wrong order by accident.
