### PR TITLE
Fix UB from incorrect Vec::set_len usage

### DIFF
--- a/src/handles.rs
+++ b/src/handles.rs
@@ -16,6 +16,8 @@
 //! the plan is to replace the internals with unsafe code that omits the
 //! bound check at the read/write time.
 
+use core::mem::MaybeUninit;
+
 #[cfg(all(
     feature = "simd-accel",
     any(
@@ -25,6 +27,8 @@
     )
 ))]
 use crate::simd_funcs::*;
+use crate::MaybeUninitSliceInitFromSlice;
+use crate::PointerStripMaybeUninit;
 
 #[cfg(all(
     feature = "simd-accel",
@@ -153,7 +157,7 @@ impl UnalignedU16Slice {
 
     #[cfg(feature = "simd-accel")]
     #[inline(always)]
-    pub fn copy_bmp_to<E: Endian>(&self, other: &mut [u16]) -> Option<(u16, usize)> {
+    pub fn copy_bmp_to<E: Endian>(&self, other: &mut [MaybeUninit<u16>]) -> Option<(u16, usize)> {
         assert!(self.len <= other.len());
         let mut offset = 0;
         // Safety: SIMD_STRIDE_SIZE is measured in bytes, whereas len is in u16s. We check we can
@@ -167,7 +171,7 @@ impl UnalignedU16Slice {
                 }
                 // Safety: we have enough space on the other side to write this
                 unsafe {
-                    store8_unaligned(other.as_mut_ptr().add(offset), simd);
+                    store8_unaligned(other.as_mut_ptr().add(offset).strip_maybeuninit(), simd);
                 }
                 if contains_surrogates(simd) {
                     break;
@@ -192,11 +196,11 @@ impl UnalignedU16Slice {
 
     #[cfg(not(feature = "simd-accel"))]
     #[inline(always)]
-    fn copy_bmp_to<E: Endian>(&self, other: &mut [u16]) -> Option<(u16, usize)> {
+    fn copy_bmp_to<E: Endian>(&self, other: &mut [MaybeUninit<u16>]) -> Option<(u16, usize)> {
         assert!(self.len <= other.len());
         for (i, target) in other.iter_mut().enumerate().take(self.len) {
             let unit = swap_if_opposite_endian::<E>(self.at(i));
-            *target = unit;
+            target.write(unit);
             if super::in_range16(unit, 0xD800, 0xE000) {
                 return Some((unit, i));
             }
@@ -208,7 +212,7 @@ impl UnalignedU16Slice {
 #[inline(always)]
 fn copy_unaligned_basic_latin_to_ascii_alu<E: Endian>(
     src: UnalignedU16Slice,
-    dst: &mut [u8],
+    dst: &mut [MaybeUninit<u8>],
     offset: usize,
 ) -> CopyAsciiResult<usize, (u16, usize)> {
     let len = ::core::cmp::min(src.len(), dst.len());
@@ -221,7 +225,7 @@ fn copy_unaligned_basic_latin_to_ascii_alu<E: Endian>(
         if unit > 0x7F {
             return CopyAsciiResult::GoOn((unit, i + offset));
         }
-        dst[i] = unit as u8;
+        dst[i].write(unit as u8);
         i += 1;
     }
 }
@@ -239,7 +243,7 @@ fn swap_if_opposite_endian<E: Endian>(unit: u16) -> u16 {
 #[inline(always)]
 fn copy_unaligned_basic_latin_to_ascii<E: Endian>(
     src: UnalignedU16Slice,
-    dst: &mut [u8],
+    dst: &mut [MaybeUninit<u8>],
 ) -> CopyAsciiResult<usize, (u16, usize)> {
     copy_unaligned_basic_latin_to_ascii_alu::<E>(src, dst, 0)
 }
@@ -248,7 +252,7 @@ fn copy_unaligned_basic_latin_to_ascii<E: Endian>(
 #[inline(always)]
 fn copy_unaligned_basic_latin_to_ascii<E: Endian>(
     src: UnalignedU16Slice,
-    dst: &mut [u8],
+    dst: &mut [MaybeUninit<u8>],
 ) -> CopyAsciiResult<usize, (u16, usize)> {
     let len = ::core::cmp::min(src.len(), dst.len());
     let mut offset = 0;
@@ -284,7 +288,7 @@ fn copy_unaligned_basic_latin_to_ascii<E: Endian>(
 #[inline(always)]
 fn convert_unaligned_utf16_to_utf8<E: Endian>(
     src: UnalignedU16Slice,
-    dst: &mut [u8],
+    dst: &mut [MaybeUninit<u8>],
 ) -> (usize, usize, bool) {
     if dst.len() < 4 {
         return (0, 0, false);
@@ -317,16 +321,16 @@ fn convert_unaligned_utf16_to_utf8<E: Endian>(
             let non_ascii_minus_surrogate_start = non_ascii.wrapping_sub(0xD800);
             if non_ascii_minus_surrogate_start > (0xDFFF - 0xD800) {
                 if non_ascii < 0x800 {
-                    dst[dst_pos] = ((non_ascii >> 6) | 0xC0) as u8;
+                    dst[dst_pos].write(((non_ascii >> 6) | 0xC0) as u8);
                     dst_pos += 1;
-                    dst[dst_pos] = ((non_ascii & 0x3F) | 0x80) as u8;
+                    dst[dst_pos].write(((non_ascii & 0x3F) | 0x80) as u8);
                     dst_pos += 1;
                 } else {
-                    dst[dst_pos] = ((non_ascii >> 12) | 0xE0) as u8;
+                    dst[dst_pos].write(((non_ascii >> 12) | 0xE0) as u8);
                     dst_pos += 1;
-                    dst[dst_pos] = (((non_ascii & 0xFC0) >> 6) | 0x80) as u8;
+                    dst[dst_pos].write((((non_ascii & 0xFC0) >> 6) | 0x80) as u8);
                     dst_pos += 1;
-                    dst[dst_pos] = ((non_ascii & 0x3F) | 0x80) as u8;
+                    dst[dst_pos].write(((non_ascii & 0x3F) | 0x80) as u8);
                     dst_pos += 1;
                 }
             } else if non_ascii_minus_surrogate_start <= (0xDBFF - 0xD800) {
@@ -340,13 +344,13 @@ fn convert_unaligned_utf16_to_utf8<E: Endian>(
                         let point = (u32::from(non_ascii) << 10) + u32::from(second)
                             - (((0xD800u32 << 10) - 0x10000u32) + 0xDC00u32);
 
-                        dst[dst_pos] = ((point >> 18) | 0xF0u32) as u8;
+                        dst[dst_pos].write(((point >> 18) | 0xF0u32) as u8);
                         dst_pos += 1;
-                        dst[dst_pos] = (((point & 0x3F000u32) >> 12) | 0x80u32) as u8;
+                        dst[dst_pos].write((((point & 0x3F000u32) >> 12) | 0x80u32) as u8);
                         dst_pos += 1;
-                        dst[dst_pos] = (((point & 0xFC0u32) >> 6) | 0x80u32) as u8;
+                        dst[dst_pos].write((((point & 0xFC0u32) >> 6) | 0x80u32) as u8);
                         dst_pos += 1;
-                        dst[dst_pos] = ((point & 0x3Fu32) | 0x80u32) as u8;
+                        dst[dst_pos].write(((point & 0x3Fu32) | 0x80u32) as u8);
                         dst_pos += 1;
                     } else {
                         // The next code unit is not a low surrogate. Don't advance
@@ -370,7 +374,7 @@ fn convert_unaligned_utf16_to_utf8<E: Endian>(
                 non_ascii = unit;
                 continue 'inner;
             }
-            dst[dst_pos] = unit as u8;
+            dst[dst_pos].write(unit as u8);
             dst_pos += 1;
             continue 'outer;
         }
@@ -588,13 +592,13 @@ where
 }
 
 pub struct Utf16Destination<'a> {
-    slice: &'a mut [u16],
+    slice: &'a mut [MaybeUninit<u16>],
     pos: usize,
 }
 
 impl<'a> Utf16Destination<'a> {
     #[inline(always)]
-    pub fn new(dst: &mut [u16]) -> Utf16Destination {
+    pub fn new(dst: &'a mut [MaybeUninit<u16>]) -> Utf16Destination<'a> {
         Utf16Destination { slice: dst, pos: 0 }
     }
     #[inline(always)]
@@ -621,7 +625,7 @@ impl<'a> Utf16Destination<'a> {
     fn write_code_unit(&mut self, u: u16) {
         unsafe {
             // OK, because we checked before handing out a handle.
-            *(self.slice.get_unchecked_mut(self.pos)) = u;
+            (self.slice.get_unchecked_mut(self.pos)).write(u);
         }
         self.pos += 1;
     }
@@ -683,7 +687,11 @@ impl<'a> Utf16Destination<'a> {
             // Safety: This function is documented as needing valid pointers for src/dest and len, which
             // is true since we've passed the minumum length of the two
             match unsafe {
-                ascii_to_basic_latin(src_remaining.as_ptr(), dst_remaining.as_mut_ptr(), length)
+                ascii_to_basic_latin(
+                    src_remaining.as_ptr(),
+                    dst_remaining.as_mut_ptr().strip_maybeuninit(),
+                    length,
+                )
             } {
                 None => {
                     source.pos += length;
@@ -721,7 +729,11 @@ impl<'a> Utf16Destination<'a> {
             // Safety: This function is documented as needing valid pointers for src/dest and len, which
             // is true since we've passed the minumum length of the two
             match unsafe {
-                ascii_to_basic_latin(src_remaining.as_ptr(), dst_remaining.as_mut_ptr(), length)
+                ascii_to_basic_latin(
+                    src_remaining.as_ptr(),
+                    dst_remaining.as_mut_ptr().strip_maybeuninit(),
+                    length,
+                )
             } {
                 None => {
                     source.pos += length;
@@ -804,7 +816,7 @@ impl<'a> Utf16Destination<'a> {
                     return Some((source.pos, self.pos));
                 }
                 // `surrogate` was already speculatively written
-                dst_remaining[second_pos] = second;
+                dst_remaining[second_pos].write(second);
                 offset += 2;
                 continue;
             } else {
@@ -933,13 +945,13 @@ where
 }
 
 pub struct Utf8Destination<'a> {
-    slice: &'a mut [u8],
+    slice: &'a mut [MaybeUninit<u8>],
     pos: usize,
 }
 
 impl<'a> Utf8Destination<'a> {
     #[inline(always)]
-    pub fn new(dst: &mut [u8]) -> Utf8Destination {
+    pub fn new(dst: &'a mut [MaybeUninit<u8>]) -> Utf8Destination<'a> {
         Utf8Destination { slice: dst, pos: 0 }
     }
     #[inline(always)]
@@ -964,10 +976,9 @@ impl<'a> Utf8Destination<'a> {
     }
     #[inline(always)]
     fn write_code_unit(&mut self, u: u8) {
-        unsafe {
-            // OK, because we checked before handing out a handle.
-            *(self.slice.get_unchecked_mut(self.pos)) = u;
-        }
+        // SAFETY: OK, because we checked before handing out a handle.
+        unsafe { self.slice.get_unchecked_mut(self.pos) }.write(u);
+
         self.pos += 1;
     }
     #[inline(always)]
@@ -1043,7 +1054,11 @@ impl<'a> Utf8Destination<'a> {
                 (DecoderResult::InputEmpty, src_remaining.len())
             };
             match unsafe {
-                ascii_to_ascii(src_remaining.as_ptr(), dst_remaining.as_mut_ptr(), length)
+                ascii_to_ascii(
+                    src_remaining.as_ptr(),
+                    dst_remaining.as_mut_ptr().strip_maybeuninit(),
+                    length,
+                )
             } {
                 None => {
                     source.pos += length;
@@ -1083,7 +1098,11 @@ impl<'a> Utf8Destination<'a> {
                 (DecoderResult::InputEmpty, src_remaining.len())
             };
             match unsafe {
-                ascii_to_ascii(src_remaining.as_ptr(), dst_remaining.as_mut_ptr(), length)
+                ascii_to_ascii(
+                    src_remaining.as_ptr(),
+                    dst_remaining.as_mut_ptr().strip_maybeuninit(),
+                    length,
+                )
             } {
                 None => {
                     source.pos += length;
@@ -1116,7 +1135,7 @@ impl<'a> Utf8Destination<'a> {
         // Validate first, then memcpy to let memcpy do its thing even for
         // non-ASCII. (And potentially do something better than SSE2 for ASCII.)
         let valid_len = utf8_valid_up_to(&src_remaining[..min_len]);
-        (&mut dst_remaining[..valid_len]).copy_from_slice(&src_remaining[..valid_len]);
+        dst_remaining[..valid_len].init_from_slice(&src_remaining[..valid_len]);
         source.pos += valid_len;
         self.pos += valid_len;
     }
@@ -1262,7 +1281,11 @@ impl<'a> Utf16Source<'a> {
                 (EncoderResult::InputEmpty, src_remaining.len())
             };
             match unsafe {
-                basic_latin_to_ascii(src_remaining.as_ptr(), dst_remaining.as_mut_ptr(), length)
+                basic_latin_to_ascii(
+                    src_remaining.as_ptr(),
+                    dst_remaining.as_mut_ptr().strip_maybeuninit(),
+                    length,
+                )
             } {
                 None => {
                     self.pos += length;
@@ -1331,7 +1354,11 @@ impl<'a> Utf16Source<'a> {
                 (EncoderResult::InputEmpty, src_remaining.len())
             };
             match unsafe {
-                basic_latin_to_ascii(src_remaining.as_ptr(), dst_remaining.as_mut_ptr(), length)
+                basic_latin_to_ascii(
+                    src_remaining.as_ptr(),
+                    dst_remaining.as_mut_ptr().strip_maybeuninit(),
+                    length,
+                )
             } {
                 None => {
                     self.pos += length;
@@ -1554,7 +1581,11 @@ impl<'a> Utf8Source<'a> {
                 (EncoderResult::InputEmpty, src_remaining.len())
             };
             match unsafe {
-                ascii_to_ascii(src_remaining.as_ptr(), dst_remaining.as_mut_ptr(), length)
+                ascii_to_ascii(
+                    src_remaining.as_ptr(),
+                    dst_remaining.as_mut_ptr().strip_maybeuninit(),
+                    length,
+                )
             } {
                 None => {
                     self.pos += length;
@@ -1604,7 +1635,11 @@ impl<'a> Utf8Source<'a> {
                 (EncoderResult::InputEmpty, src_remaining.len())
             };
             match unsafe {
-                ascii_to_ascii(src_remaining.as_ptr(), dst_remaining.as_mut_ptr(), length)
+                ascii_to_ascii(
+                    src_remaining.as_ptr(),
+                    dst_remaining.as_mut_ptr().strip_maybeuninit(),
+                    length,
+                )
             } {
                 None => {
                     self.pos += length;
@@ -1660,7 +1695,11 @@ impl<'a> Utf8Source<'a> {
                 (EncoderResult::InputEmpty, src_remaining.len())
             };
             match unsafe {
-                ascii_to_ascii(src_remaining.as_ptr(), dst_remaining.as_mut_ptr(), length)
+                ascii_to_ascii(
+                    src_remaining.as_ptr(),
+                    dst_remaining.as_mut_ptr().strip_maybeuninit(),
+                    length,
+                )
             } {
                 None => {
                     self.pos += length;
@@ -1915,22 +1954,22 @@ where
 }
 
 pub struct ByteDestination<'a> {
-    slice: &'a mut [u8],
+    slice: &'a mut [MaybeUninit<u8>],
     /// Pointer to the original start of the slice. It's never dereferenced.
-    start: *const u8,
+    start: *const MaybeUninit<u8>,
 }
 
 impl<'a> ByteDestination<'a> {
     #[inline(always)]
-    pub fn new(dst: &mut [u8]) -> ByteDestination {
+    pub fn new(dst: &'a mut [MaybeUninit<u8>]) -> ByteDestination<'a> {
         ByteDestination {
             start: dst.as_ptr(),
             slice: dst,
         }
     }
     #[inline(always)]
-    pub fn remaining(&mut self) -> &mut [u8] {
-        &mut self.slice
+    pub fn remaining(&mut self) -> &mut [MaybeUninit<u8>] {
+        self.slice
     }
     #[inline(always)]
     pub fn check_space_one<'b>(&'b mut self) -> Space<ByteOneHandle<'b, 'a>> {
@@ -1975,24 +2014,24 @@ impl<'a> ByteDestination<'a> {
         let (dst, rest) = core::mem::take(&mut self.slice).split_first_mut().unwrap();
         self.slice = rest;
 
-        *dst = first;
+        dst.write(first);
     }
     #[inline(always)]
     fn write_two(&mut self, first: u8, second: u8) {
         let (dst, rest) = core::mem::take(&mut self.slice).split_at_mut(2);
         self.slice = rest;
 
-        dst[0] = first;
-        dst[1] = second;
+        dst[0].write(first);
+        dst[1].write(second);
     }
     #[inline(always)]
     fn write_three(&mut self, first: u8, second: u8, third: u8) {
         let (dst, rest) = core::mem::take(&mut self.slice).split_at_mut(3);
         self.slice = rest;
 
-        dst[0] = first;
-        dst[1] = second;
-        dst[2] = third;
+        dst[0].write(first);
+        dst[1].write(second);
+        dst[2].write(third);
     }
     #[inline(always)]
     fn write_four(&mut self, first: u8, second: u8, third: u8, fourth: u8) {
@@ -2000,10 +2039,10 @@ impl<'a> ByteDestination<'a> {
         let (dst, rest) = core::mem::take(&mut self.slice).split_at_mut(4);
         self.slice = rest;
 
-        dst[0] = first;
-        dst[1] = second;
-        dst[2] = third;
-        dst[3] = fourth;
+        dst[0].write(first);
+        dst[1].write(second);
+        dst[2].write(third);
+        dst[3].write(fourth);
     }
     /// Assume this many bytes have been written
     #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4011,11 +4011,11 @@ impl Decoder {
                     // otherwise we'd have gotten OutputFull already.
                     // XXX: is the above comment actually true for UTF-8 itself?
                     // TODO: Consider having fewer bound checks here.
-                    dst[total_written].write(0xEFu8);
+                    dst[total_written] = MaybeUninit::new(0xEFu8);
                     total_written += 1;
-                    dst[total_written].write(0xBFu8);
+                    dst[total_written] = MaybeUninit::new(0xBFu8);
                     total_written += 1;
-                    dst[total_written].write(0xBDu8);
+                    dst[total_written] = MaybeUninit::new(0xBDu8);
                     total_written += 1;
                 }
             }
@@ -4898,19 +4898,19 @@ fn write_ncr(unmappable: char, dst: &mut [MaybeUninit<u8>]) -> usize {
     debug_assert!(number >= 10u32);
     debug_assert!(len <= dst.len());
     let mut pos = len - 1;
-    dst[pos].write(b';');
+    dst[pos] = MaybeUninit::new(b';');
     pos -= 1;
     loop {
         let rightmost = number % 10;
-        dst[pos].write(rightmost as u8 + b'0');
+        dst[pos] = MaybeUninit::new(rightmost as u8 + b'0');
         pos -= 1;
         if number < 10 {
             break;
         }
         number /= 10;
     }
-    dst[1].write(b'#');
-    dst[0].write(b'&');
+    dst[1] = MaybeUninit::new(b'#');
+    dst[0] = MaybeUninit::new(b'&');
     len
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3131,8 +3131,8 @@ impl Encoding {
             );
             unsafe {
                 let vec = string.as_mut_vec();
-                vec.set_len(valid_up_to);
                 core::ptr::copy_nonoverlapping(bytes.as_ptr(), vec.as_mut_ptr(), valid_up_to);
+                vec.set_len(valid_up_to);
             }
             (decoder, string, valid_up_to)
         } else {
@@ -3232,8 +3232,8 @@ impl Encoding {
             );
             unsafe {
                 let vec = string.as_mut_vec();
-                vec.set_len(valid_up_to);
                 core::ptr::copy_nonoverlapping(bytes.as_ptr(), vec.as_mut_ptr(), valid_up_to);
+                vec.set_len(valid_up_to);
             }
             (decoder, string, &bytes[valid_up_to..])
         } else {
@@ -3323,8 +3323,8 @@ impl Encoding {
             .next_power_of_two(),
         );
         unsafe {
-            vec.set_len(valid_up_to);
             core::ptr::copy_nonoverlapping(bytes.as_ptr(), vec.as_mut_ptr(), valid_up_to);
+            vec.set_len(valid_up_to);
         }
         let mut total_read = valid_up_to;
         let mut total_had_errors = false;
@@ -4074,16 +4074,13 @@ impl Decoder {
         dst: &mut String,
         last: bool,
     ) -> (CoderResult, usize, bool) {
-        unsafe {
-            let vec = dst.as_mut_vec();
-            let old_len = vec.len();
-            let capacity = vec.capacity();
-            vec.set_len(capacity);
-            let (result, read, written, replaced) =
-                self.decode_to_utf8(src, &mut vec[old_len..], last);
-            vec.set_len(old_len + written);
-            (result, read, replaced)
-        }
+        let vec = unsafe { dst.as_mut_vec() };
+        let old_len = vec.len();
+        let capacity = vec.capacity();
+        vec.resize(capacity, 0);
+        let (result, read, written, replaced) = self.decode_to_utf8(src, &mut vec[old_len..], last);
+        vec.truncate(old_len + written);
+        (result, read, replaced)
     }
 
     public_decode_function!(/// Incrementally decode a byte stream into UTF-8
@@ -4164,16 +4161,14 @@ impl Decoder {
         dst: &mut String,
         last: bool,
     ) -> (DecoderResult, usize) {
-        unsafe {
-            let vec = dst.as_mut_vec();
-            let old_len = vec.len();
-            let capacity = vec.capacity();
-            vec.set_len(capacity);
-            let (result, read, written) =
-                self.decode_to_utf8_without_replacement(src, &mut vec[old_len..], last);
-            vec.set_len(old_len + written);
-            (result, read)
-        }
+        let vec = unsafe { dst.as_mut_vec() };
+        let old_len = vec.len();
+        let capacity = vec.capacity();
+        vec.resize(capacity, 0);
+        let (result, read, written) =
+            self.decode_to_utf8_without_replacement(src, &mut vec[old_len..], last);
+        vec.truncate(old_len + written);
+        (result, read)
     }
 
     /// Query the worst-case UTF-16 output size (with or without replacement).
@@ -4665,15 +4660,13 @@ impl Encoder {
         dst: &mut Vec<u8>,
         last: bool,
     ) -> (CoderResult, usize, bool) {
-        unsafe {
-            let old_len = dst.len();
-            let capacity = dst.capacity();
-            dst.set_len(capacity);
-            let (result, read, written, replaced) =
-                self.encode_from_utf8(src, &mut dst[old_len..], last);
-            dst.set_len(old_len + written);
-            (result, read, replaced)
-        }
+        let old_len = dst.len();
+        let capacity = dst.capacity();
+        dst.resize(capacity, 0);
+        let (result, read, written, replaced) =
+            self.encode_from_utf8(src, &mut dst[old_len..], last);
+        dst.truncate(old_len + written);
+        (result, read, replaced)
     }
 
     /// Incrementally encode into byte stream from UTF-8 _without replacement_.
@@ -4705,15 +4698,13 @@ impl Encoder {
         dst: &mut Vec<u8>,
         last: bool,
     ) -> (EncoderResult, usize) {
-        unsafe {
-            let old_len = dst.len();
-            let capacity = dst.capacity();
-            dst.set_len(capacity);
-            let (result, read, written) =
-                self.encode_from_utf8_without_replacement(src, &mut dst[old_len..], last);
-            dst.set_len(old_len + written);
-            (result, read)
-        }
+        let old_len = dst.len();
+        let capacity = dst.capacity();
+        dst.resize(capacity, 0);
+        let (result, read, written) =
+            self.encode_from_utf8_without_replacement(src, &mut dst[old_len..], last);
+        dst.truncate(old_len + written);
+        (result, read)
     }
 
     /// Query the worst-case output size when encoding from UTF-16 with

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -1518,7 +1518,7 @@ pub fn convert_utf8_to_utf16_maybeuninit(src: &[u8], dst: &mut [MaybeUninit<u16>
             DecoderResult::Malformed(_, _) => {
                 // There should always be space for the U+FFFD, because
                 // otherwise we'd have gotten OutputFull already.
-                dst[total_written].write(0xFFFD);
+                dst[total_written] = MaybeUninit::new(0xFFFD);
                 total_written += 1;
             }
         }

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -2017,10 +2017,8 @@ pub fn decode_latin1<'a>(bytes: &'a [u8]) -> Cow<'a, str> {
     let (head, tail) = bytes.split_at(up_to);
     let capacity = head.len() + tail.len() * 2;
     let mut vec = Vec::with_capacity(capacity);
-    unsafe {
-        vec.set_len(capacity);
-    }
-    (&mut vec[..up_to]).copy_from_slice(head);
+    vec.extend(head);
+    vec.resize(capacity, 0);
     let written = convert_latin1_to_utf8(tail, &mut vec[up_to..]);
     vec.truncate(up_to + written);
     Cow::Owned(unsafe { String::from_utf8_unchecked(vec) })
@@ -2054,10 +2052,8 @@ pub fn encode_latin1_lossy<'a>(string: &'a str) -> Cow<'a, [u8]> {
     let (head, tail) = bytes.split_at(up_to);
     let capacity = bytes.len();
     let mut vec = Vec::with_capacity(capacity);
-    unsafe {
-        vec.set_len(capacity);
-    }
-    (&mut vec[..up_to]).copy_from_slice(head);
+    vec.extend(head);
+    vec.resize(capacity, 0);
     let written = convert_utf8_to_latin1_lossy(tail, &mut vec[up_to..]);
     vec.truncate(up_to + written);
     Cow::Owned(vec)

--- a/src/replacement.rs
+++ b/src/replacement.rs
@@ -34,7 +34,7 @@ impl ReplacementDecoder {
     pub fn decode_to_utf16_raw(
         &mut self,
         src: &[u8],
-        dst: &mut [u16],
+        dst: &mut [MaybeUninit<u16>],
         _last: bool,
     ) -> (DecoderResult, usize, usize) {
         // Don't err if the input stream is empty. See
@@ -53,7 +53,7 @@ impl ReplacementDecoder {
     pub fn decode_to_utf8_raw(
         &mut self,
         src: &[u8],
-        dst: &mut [u8],
+        dst: &mut [MaybeUninit<u8>],
         _last: bool,
     ) -> (DecoderResult, usize, usize) {
         // Don't err if the input stream is empty. See

--- a/src/single_byte.rs
+++ b/src/single_byte.rs
@@ -201,7 +201,7 @@ impl SingleByteDecoder {
                             );
                         }
                         // Safety: As mentioned above, `converted < length`
-                        unsafe { dst.get_unchecked_mut(converted) }.write(mapped);
+                        *unsafe { dst.get_unchecked_mut(converted) } = MaybeUninit::new(mapped);
 
                         // Safety: `converted <= length` upheld, since `converted < length` before this
                         converted += 1;
@@ -229,7 +229,8 @@ impl SingleByteDecoder {
                             // byte unconditionally instead of trying to unread it
                             // to make it part of the next SIMD stride.
                             // Safety: `converted < length` is true for this loop
-                            unsafe { dst.get_unchecked_mut(converted) }.write(u16::from(b));
+                            *unsafe { dst.get_unchecked_mut(converted) } =
+                                MaybeUninit::new(u16::from(b));
 
                             // Safety: We are now at `converted <= length`. We should *not* `continue`
                             // the loop without reverifying
@@ -439,7 +440,8 @@ impl SingleByteEncoder {
                         match self.encode_u16(non_ascii) {
                             Some(byte) => {
                                 // Safety: we're allowed this access since `converted < length`
-                                unsafe { dst.get_unchecked_mut(converted) }.write(byte);
+                                *unsafe { dst.get_unchecked_mut(converted) } =
+                                    MaybeUninit::new(byte);
 
                                 converted += 1;
                                 // `converted <= length` now
@@ -535,7 +537,8 @@ impl SingleByteEncoder {
                             // byte unconditionally instead of trying to unread it
                             // to make it part of the next SIMD stride.
                             // Safety: Can rely on converted < length
-                            unsafe { dst.get_unchecked_mut(converted) }.write(unit as u8);
+                            *unsafe { dst.get_unchecked_mut(converted) } =
+                                MaybeUninit::new(unit as u8);
 
                             converted += 1;
                             // `converted <= length` here

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -19,6 +19,8 @@
 //! The purpose of making `Decoder` and `Encoder` `Sized` is to allow stack
 //! allocation in Rust code, including the convenience methods on `Encoding`.
 
+use core::mem::MaybeUninit;
+
 use super::*;
 use big5::*;
 use euc_jp::*;
@@ -120,7 +122,7 @@ impl VariantDecoder {
     pub fn decode_to_utf16_raw(
         &mut self,
         src: &[u8],
-        dst: &mut [u16],
+        dst: &mut [MaybeUninit<u16>],
         last: bool,
     ) -> (DecoderResult, usize, usize) {
         match *self {
@@ -141,7 +143,7 @@ impl VariantDecoder {
     pub fn decode_to_utf8_raw(
         &mut self,
         src: &[u8],
-        dst: &mut [u8],
+        dst: &mut [MaybeUninit<u8>],
         last: bool,
     ) -> (DecoderResult, usize, usize) {
         match *self {
@@ -301,7 +303,7 @@ impl VariantEncoder {
     pub fn encode_from_utf16_raw(
         &mut self,
         src: &[u16],
-        dst: &mut [u8],
+        dst: &mut [MaybeUninit<u8>],
         last: bool,
     ) -> (EncoderResult, usize, usize) {
         match *self {
@@ -320,7 +322,7 @@ impl VariantEncoder {
     pub fn encode_from_utf8_raw(
         &mut self,
         src: &str,
-        dst: &mut [u8],
+        dst: &mut [MaybeUninit<u8>],
         last: bool,
     ) -> (EncoderResult, usize, usize) {
         match *self {

--- a/src/x_user_defined.rs
+++ b/src/x_user_defined.rs
@@ -76,7 +76,7 @@ impl UserDefinedDecoder {
     pub fn decode_to_utf16_raw(
         &mut self,
         src: &[u8],
-        dst: &mut [u16],
+        dst: &mut [MaybeUninit<u16>],
         _last: bool,
     ) -> (DecoderResult, usize, usize) {
         let (pending, length) = if dst.len() < src.len() {
@@ -90,14 +90,14 @@ impl UserDefinedDecoder {
             .iter()
             .zip(dst_trim.iter_mut())
             .for_each(|(from, to)| {
-                *to = {
+                to.write({
                     let unit = *from;
                     if unit < 0x80 {
                         u16::from(unit)
                     } else {
                         u16::from(unit) + 0xF700
                     }
-                }
+                });
             });
         (pending, length, length)
     }

--- a/src/x_user_defined.rs
+++ b/src/x_user_defined.rs
@@ -90,7 +90,7 @@ impl UserDefinedDecoder {
             .iter()
             .zip(dst_trim.iter_mut())
             .for_each(|(from, to)| {
-                to.write({
+                *to = MaybeUninit::new({
                     let unit = *from;
                     if unit < 0x80 {
                         u16::from(unit)


### PR DESCRIPTION
The clippy::uninit_vec lint pointed out this issue in a few places, and then some manual review found many more places where Vec::set_len was being abused.

This introduces buffer zeroing in several places, which will have a performance impact. In order to safely avoid this zeroing, we will need to support `&mut [MaybeUninit<u8>]` as an output buffer.

For more information, see the clippy lint's documentation: https://rust-lang.github.io/rust-clippy/master/index.html#uninit_vec