### PR TITLE
Use finish_non_exhaustive() in Debug for Encoding, Encoder, and Decoder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3493,7 +3493,7 @@ impl core::fmt::Debug for Encoding {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("Encoding")
             .field("name", &self.name)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -4430,7 +4430,7 @@ impl core::fmt::Debug for Decoder {
         f.debug_struct("Decoder")
             .field("encoding", self.encoding)
             .field("life_cycle", &self.life_cycle)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -4955,7 +4955,7 @@ impl core::fmt::Debug for Encoder {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         f.debug_struct("Encoder")
             .field("encoding", self.encoding)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
Use [`finish_non_exhaustive()`](https://doc.rust-lang.org/1.88/std/fmt/struct.DebugStruct.html#method.finish_non_exhaustive), which was not available on Rust 1.40, instead of [`finish()`](https://doc.rust-lang.org/1.88/std/fmt/struct.DebugStruct.html#method.finish) in Debug implementations for Encoding, Encoder, and Decoder.